### PR TITLE
add universal prefix to constant values

### DIFF
--- a/src/OTS/ColumnTypeConst.php
+++ b/src/OTS/ColumnTypeConst.php
@@ -4,33 +4,33 @@ namespace Aliyun\OTS;
 
 /* 该类被使用于描述主键和属性列的数据类型。 */
 class ColumnTypeConst {
-    const STRING = 'STRING';
-    const INTEGER = 'INTEGER';
-    const BOOLEAN = 'BOOLEAN';
-    const DOUBLE = 'DOUBLE';
-    const BINARY = 'BINARY';
-    const INF_MIN = 'INF_MIN';
-    const INF_MAX = 'INF_MAX';
+    const CONST_STRING = 'STRING';
+    const CONST_INTEGER = 'INTEGER';
+    const CONST_BOOLEAN = 'BOOLEAN';
+    const CONST_DOUBLE = 'DOUBLE';
+    const CONST_BINARY = 'BINARY';
+    const CONST_INF_MIN = 'INF_MIN';
+    const CONST_INF_MAX = 'INF_MAX';
     static public function values() {
         return array (
-                ColumnTypeConst::BINARY,
-                ColumnTypeConst::BOOLEAN,
-                ColumnTypeConst::DOUBLE,
-                ColumnTypeConst::INTEGER,
-                ColumnTypeConst::STRING,
-                ColumnTypeConst::INF_MAX,
-                ColumnTypeConst::INF_MIN 
+                ColumnTypeConst::CONST_BINARY,
+                ColumnTypeConst::CONST_BOOLEAN,
+                ColumnTypeConst::CONST_DOUBLE,
+                ColumnTypeConst::CONST_INTEGER,
+                ColumnTypeConst::CONST_STRING,
+                ColumnTypeConst::CONST_INF_MAX,
+                ColumnTypeConst::CONST_INF_MIN 
         );
     }
     static public function members() {
         return array (
-                'ColumnTypeConst::BINARY',
-                'ColumnTypeConst::BOOLEAN',
-                'ColumnTypeConst::DOUBLE',
-                'ColumnTypeConst::INTEGER',
-                'ColumnTypeConst::STRING',
-                'ColumnTypeConst::INF_MAX',
-                'ColumnTypeConst::INF_MIN' 
+                'ColumnTypeConst::CONST_BINARY',
+                'ColumnTypeConst::CONST_BOOLEAN',
+                'ColumnTypeConst::CONST_DOUBLE',
+                'ColumnTypeConst::CONST_INTEGER',
+                'ColumnTypeConst::CONST_STRING',
+                'ColumnTypeConst::CONST_INF_MAX',
+                'ColumnTypeConst::CONST_INF_MIN' 
         );
     }
 }

--- a/src/OTS/ComparatorTypeConst.php
+++ b/src/OTS/ComparatorTypeConst.php
@@ -4,30 +4,30 @@ namespace Aliyun\OTS;
 
 /* 该类表示比较运算符。 */
 class ComparatorTypeConst {
-    const EQUAL = 1;
-    const NOT_EQUAL = 2;
-    const GREATER_THAN = 3;
-    const GREATER_EQUAL = 4;
-    const LESS_THAN = 5;
-    const LESS_EQUAL = 6;
+    const CONST_EQUAL = 1;
+    const CONST_NOT_EQUAL = 2;
+    const CONST_GREATER_THAN = 3;
+    const CONST_GREATER_EQUAL = 4;
+    const CONST_LESS_THAN = 5;
+    const CONST_LESS_EQUAL = 6;
     static public function values() {
         return array (
-                ComparatorTypeConst::EQUAL,
-                ComparatorTypeConst::NOT_EQUAL,
-                ComparatorTypeConst::LESS_THAN,
-                ComparatorTypeConst::LESS_EQUAL,
-                ComparatorTypeConst::GREATER_THAN,
-                ComparatorTypeConst::GREATER_EQUAL 
+                ComparatorTypeConst::CONST_EQUAL,
+                ComparatorTypeConst::CONST_NOT_EQUAL,
+                ComparatorTypeConst::CONST_LESS_THAN,
+                ComparatorTypeConst::CONST_LESS_EQUAL,
+                ComparatorTypeConst::CONST_GREATER_THAN,
+                ComparatorTypeConst::CONST_GREATER_EQUAL 
         );
     }
     static public function memebers() {
         return array (
-                'ComparatorTypeConst::EQUAL',
-                'ComparatorTypeConst::NOT_EQUAL',
-                'ComparatorTypeConst::LESS_THAN',
-                'ComparatorTypeConst::LESS_EQUAL',
-                'ComparatorTypeConst::GREATER_THAN',
-                'ComparatorTypeConst::GREATER_EQUAL' 
+                'ComparatorTypeConst::CONST_EQUAL',
+                'ComparatorTypeConst::CONST_NOT_EQUAL',
+                'ComparatorTypeConst::CONST_LESS_THAN',
+                'ComparatorTypeConst::CONST_LESS_EQUAL',
+                'ComparatorTypeConst::CONST_GREATER_THAN',
+                'ComparatorTypeConst::CONST_GREATER_EQUAL' 
         );
     }
 }

--- a/src/OTS/DirectionConst.php
+++ b/src/OTS/DirectionConst.php
@@ -4,18 +4,18 @@ namespace Aliyun\OTS;
 
 /* 该类用于描述数据查询的返回结果的排列方式。 */
 class DirectionConst {
-    const FORWARD = 'FORWARD';
-    const BACKWARD = 'BACKWARD';
+    const CONST_FORWARD = 'FORWARD';
+    const CONST_BACKWARD = 'BACKWARD';
     static public function values() {
         return array (
-                DirectionConst::FORWARD,
-                DirectionConst::BACKWARD 
+                DirectionConst::CONST_FORWARD,
+                DirectionConst::CONST_BACKWARD 
         );
     }
     static public function memebers() {
         return array (
-                'DirectionConst::FORWARD',
-                'DirectionConst::BACKWARD' 
+                'DirectionConst::CONST_FORWARD',
+                'DirectionConst::CONST_BACKWARD' 
         );
     }
 }

--- a/src/OTS/Handlers/ProtoBufferEncoder.php
+++ b/src/OTS/Handlers/ProtoBufferEncoder.php
@@ -22,9 +22,9 @@ use TableInBatchWriteRowRequest;
 use PutRowInBatchWriteRowRequest;
 use UpdateRowInBatchWriteRowRequest;
 use DeleteRowInBatchWriteRowRequest;
-use LogicalOperatorConst;
-use ComparatorTypeConst;
-use RowExistenceExpectationConst;
+use Aliyun\OTS\LogicalOperatorConst;
+use Aliyun\OTS\ComparatorTypeConst;
+use Aliyun\OTS\RowExistenceExpectationConst;
 
 class ProtoBufferEncoder
 {
@@ -120,8 +120,8 @@ class ProtoBufferEncoder
     private function preprocessLogicalOperator($logical_operator) 
     {   
     	if ( !is_int($logical_operator) || 
-    	        ( $logical_operator != LogicalOperatorConst::AND && $logical_operator != LogicalOperatorConst::OR && $logical_operator != LogicalOperatorConst::NOT ) )
-    	    throw new \Aliyun\OTS\OTSClientException("LogicalOperator must be one of 'LogicalOperatorConst::AND', 'LogicalOperatorConst::OR' or 'LogicalOperatorConst::NOT'.");
+    	        ( $logical_operator != LogicalOperatorConst::CONST_AND && $logical_operator != LogicalOperatorConst::CONST_OR && $logical_operator != LogicalOperatorConst::CONST_NOT ) )
+    	    throw new \Aliyun\OTS\OTSClientException("LogicalOperator must be one of 'LogicalOperatorConst::CONST_AND', 'LogicalOperatorConst::CONST_OR' or 'LogicalOperatorConst::CONST_NOT'.");
     	
     	return $logical_operator;
     }
@@ -129,13 +129,13 @@ class ProtoBufferEncoder
     private function preprocessComparatorType($comparator_type) 
     {
     	if ( !is_int($comparator_type) || 
-    	        ( $comparator_type != ComparatorTypeConst::EQUAL && 
-    	                $comparator_type != ComparatorTypeConst::NOT_EQUAL && 
-    	                $comparator_type != ComparatorTypeConst::GREATER_THAN && 
-    	                $comparator_type != ComparatorTypeConst::GREATER_EQUAL &&
-    	                $comparator_type != ComparatorTypeConst::LESS_THAN &&
-    	                $comparator_type != ComparatorTypeConst::LESS_EQUAL ) )
-    	    throw new \Aliyun\OTS\OTSClientException("Comparator must be one of 'ComparatorTypeConst::EQUAL', 'ComparatorTypeConst::NOT_EQUAL', 'ComparatorTypeConst::LESS_THAN', 'ComparatorTypeConst::LESS_EQUAL', 'ComparatorTypeConst::GREATER_THAN' or 'ComparatorTypeConst::GREATER_EQUAL'.");
+    	        ( $comparator_type != ComparatorTypeConst::CONST_EQUAL && 
+    	                $comparator_type != ComparatorTypeConst::CONST_NOT_EQUAL && 
+    	                $comparator_type != ComparatorTypeConst::CONST_GREATER_THAN && 
+    	                $comparator_type != ComparatorTypeConst::CONST_GREATER_EQUAL &&
+    	                $comparator_type != ComparatorTypeConst::CONST_LESS_THAN &&
+    	                $comparator_type != ComparatorTypeConst::CONST_LESS_EQUAL ) )
+    	    throw new \Aliyun\OTS\OTSClientException("Comparator must be one of 'ComparatorTypeConst::CONST_EQUAL', 'ComparatorTypeConst::CONST_NOT_EQUAL', 'ComparatorTypeConst::CONST_LESS_THAN', 'ComparatorTypeConst::CONST_LESS_EQUAL', 'ComparatorTypeConst::CONST_GREATER_THAN' or 'ComparatorTypeConst::CONST_GREATER_EQUAL'.");
  
     	return $comparator_type;
     }
@@ -143,14 +143,14 @@ class ProtoBufferEncoder
     private function preprocessRowExistence($condition)
     {
     	$value=null;
-    	if ( strcmp($condition, RowExistenceExpectationConst::IGNORE) == 0 )
+    	if ( strcmp($condition, RowExistenceExpectationConst::CONST_IGNORE) == 0 )
     		$value = \RowExistenceExpectation::IGNORE;
-    	else if ( strcmp($condition, RowExistenceExpectationConst::EXPECT_EXIST) == 0 )
+    	else if ( strcmp($condition, RowExistenceExpectationConst::CONST_EXPECT_EXIST) == 0 )
     		$value = \RowExistenceExpectation::EXPECT_EXIST;
-    	else if ( strcmp($condition, RowExistenceExpectationConst::EXPECT_NOT_EXIST) == 0 )
+    	else if ( strcmp($condition, RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST) == 0 )
     		$value = \RowExistenceExpectation::EXPECT_NOT_EXIST;
     	else {
-    		throw new \Aliyun\OTS\OTSClientException("Condition must be one of 'RowExistenceExpectationConst::IGNORE', 'RowExistenceExpectationConst::EXPECT_EXIST' or 'RowExistenceExpectationConst::EXPECT_NOT_EXIST'.");
+    		throw new \Aliyun\OTS\OTSClientException("Condition must be one of 'RowExistenceExpectationConst::CONST_IGNORE', 'RowExistenceExpectationConst::CONST_EXPECT_EXIST' or 'RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST'.");
     	}
     	return $value;
     }

--- a/src/OTS/LogicalOperatorConst.php
+++ b/src/OTS/LogicalOperatorConst.php
@@ -4,21 +4,21 @@ namespace Aliyun\OTS;
 
 /* 该类表示逻辑运算符。 */
 class LogicalOperatorConst {
-    const NOT = 1;
-    const AND = 2;
-    const OR = 3;
+    const CONST_NOT = 1;
+    const CONST_AND = 2;
+    const CONST_OR = 3;
     static public function values() {
         return array (
-                LogicalOperationConst::AND,
-                LogicalOperationConst::OR,
-                LogicalOperationConst::NOT 
+                LogicalOperatorConst::CONST_AND,
+                LogicalOperatorConst::CONST_OR,
+                LogicalOperatorConst::CONST_NOT 
         );
     }
     static public function memebers() {
         return array (
-                'LogicalOperationConst::AND',
-                'LogicalOperationConst::OR',
-                'LogicalOperationConst::NOT' 
+                'LogicalOperatorConst::CONST_AND',
+                'LogicalOperatorConst::CONST_OR',
+                'LogicalOperatorConst::CONST_NOT' 
         );
     }
 }

--- a/src/OTS/RowExistenceExpectationConst.php
+++ b/src/OTS/RowExistenceExpectationConst.php
@@ -4,21 +4,21 @@ namespace Aliyun\OTS;
 
 /* 该类用于描述对于数据行是否存在的期望值。 */
 class RowExistenceExpectationConst {
-    const IGNORE = 'IGNORE';
-    const EXPECT_EXIST = 'EXPECT_EXIST';
-    const EXPECT_NOT_EXIST = 'EXPECT_NOT_EXIST';
+    const CONST_IGNORE = 'IGNORE';
+    const CONST_EXPECT_EXIST = 'EXPECT_EXIST';
+    const CONST_EXPECT_NOT_EXIST = 'EXPECT_NOT_EXIST';
     static public function values() {
         return array (
-                RowExistenceExpectationConst::IGNORE,
-                RowExistenceExpectationConst::EXPECT_EXIST,
-                RowExistenceExpectationConst::EXPECT_NOT_EXIST 
+                RowExistenceExpectationConst::CONST_IGNORE,
+                RowExistenceExpectationConst::CONST_EXPECT_EXIST,
+                RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST 
         );
     }
     static public function members() {
         return array (
-                'RowExistenceExpectationConst::IGNORE',
-                'RowExistenceExpectationConst::EXPECT_EXIST',
-                'RowExistenceExpectationConst::EXPECT_NOT_EXIST' 
+                'RowExistenceExpectationConst::CONST_IGNORE',
+                'RowExistenceExpectationConst::CONST_EXPECT_EXIST',
+                'RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST' 
         );
     }
 }

--- a/src/OTS/Tests/BatchGetRowTest.php
+++ b/src/OTS/Tests/BatchGetRowTest.php
@@ -4,6 +4,8 @@ namespace Aliyun\OTS\Tests;
 
 use Aliyun\OTS;
 use Aliyun\OTS\RowExistenceExpectationConst;
+use Aliyun\OTS\LogicalOperatorConst;
+use Aliyun\OTS\ComparatorTypeConst;
 use Aliyun\OTS\ColumnTypeConst;
 
 require __DIR__ . "/TestBase.php";
@@ -21,8 +23,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -38,7 +40,7 @@ class BatchGetRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -106,7 +108,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 10; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -238,7 +240,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 10; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -303,7 +305,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 10; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -370,7 +372,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 10; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -386,8 +388,8 @@ class BatchGetRowTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[1],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::INTEGER,
-                    "PK2" => ColumnTypeConst::STRING
+                    "PK1" => ColumnTypeConst::CONST_INTEGER,
+                    "PK2" => ColumnTypeConst::CONST_STRING
                 )
             ),
             "reserved_throughput" => array (
@@ -400,7 +402,7 @@ class BatchGetRowTest extends SDKTestBase {
         $this->otsClient->createTable ($tablebody);
         $table = array (
             "table_name" => $usedTables[1],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -476,7 +478,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 100; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -520,17 +522,17 @@ class BatchGetRowTest extends SDKTestBase {
                         )
                     ),
                     "column_filter" => array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr1",
                                 "value" => 1,
-                                "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                             ),
                             array (
                                 "column_name" => "attr2",
                                 "value" => "a6",
-                                "comparator" => ComparatorTypeConst::LESS_THAN
+                                "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                             )
                         )
                     )
@@ -582,7 +584,7 @@ class BatchGetRowTest extends SDKTestBase {
                     "column_filter" => array (
                         "column_name" => "attr1",
                         "value" => 100,
-                        "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                        "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                     )
                 )
             )
@@ -604,7 +606,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 100; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -651,30 +653,30 @@ class BatchGetRowTest extends SDKTestBase {
                         )
                     ),
                     "column_filter" => array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr1",
                                 "value" => 1,
-                                "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                             ),
                             array (
                                 "column_name" => "attr2",
                                 "value" => "a6",
-                                "comparator" => ComparatorTypeConst::LESS_THAN
+                                "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                             ),
                             array (
-                                "logical_operator" => LogicalOperatorConst::OR,
+                                "logical_operator" => LogicalOperatorConst::CONST_OR,
                                 "sub_conditions" => array (
                                     array (
                                         "column_name" => "attr1",
                                         "value" => 100,
-                                        "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                     ),
                                     array (
                                         "column_name" => "attr2",
                                         "value" => "a0",
-                                        "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                     )
                                 )
                             )
@@ -700,7 +702,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 100; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -718,8 +720,8 @@ class BatchGetRowTest extends SDKTestBase {
                 "table_meta" => array (
                     "table_name" => $usedTables[1],
                     "primary_key_schema" => array (
-                        "PK1" => ColumnTypeConst::INTEGER,
-                        "PK2" => ColumnTypeConst::STRING
+                        "PK1" => ColumnTypeConst::CONST_INTEGER,
+                        "PK2" => ColumnTypeConst::CONST_STRING
                     )
                 ),
                 "reserved_throughput" => array (
@@ -732,7 +734,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 100; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[1],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -780,30 +782,30 @@ class BatchGetRowTest extends SDKTestBase {
                         )
                     ),
                     "column_filter" => array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr1",
                                 "value" => 1,
-                                "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                             ),
                             array (
                                 "column_name" => "attr2",
                                 "value" => "a6",
-                                "comparator" => ComparatorTypeConst::LESS_THAN
+                                "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                             ),
                             array (
-                                "logical_operator" => LogicalOperatorConst::OR,
+                                "logical_operator" => LogicalOperatorConst::CONST_OR,
                                 "sub_conditions" => array (
                                     array (
                                         "column_name" => "attr1",
                                         "value" => 100,
-                                        "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                     ),
                                     array (
                                         "column_name" => "attr2",
                                         "value" => "a0",
-                                        "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                     )
                                 )
                             )
@@ -845,7 +847,7 @@ class BatchGetRowTest extends SDKTestBase {
                     "column_filter" => array (
                         "column_name" => "attr1",
                         "value" => 3,
-                        "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                        "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                     )
                 )
             )
@@ -875,7 +877,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 100; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -893,8 +895,8 @@ class BatchGetRowTest extends SDKTestBase {
                 "table_meta" => array (
                     "table_name" => $usedTables[1],
                     "primary_key_schema" => array (
-                        "PK1" => ColumnTypeConst::INTEGER,
-                        "PK2" => ColumnTypeConst::STRING
+                        "PK1" => ColumnTypeConst::CONST_INTEGER,
+                        "PK2" => ColumnTypeConst::CONST_STRING
                     )
                 ),
                 "reserved_throughput" => array (
@@ -907,7 +909,7 @@ class BatchGetRowTest extends SDKTestBase {
         for($i = 1; $i < 100; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[1],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -955,30 +957,30 @@ class BatchGetRowTest extends SDKTestBase {
                         )
                     ),
                     "column_filter" => array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr1",
                                 "value" => 1,
-                                "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                             ),
                             array (
                                 "column_name" => "attr2",
                                 "value" => "a6",
-                                "comparator" => ComparatorTypeConst::LESS_THAN
+                                "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                             ),
                             array (
-                                "logical_operator" => LogicalOperatorConst::OR,
+                                "logical_operator" => LogicalOperatorConst::CONST_OR,
                                 "sub_conditions" => array (
                                     array (
                                         "column_name" => "attr1",
                                         "value" => 100,
-                                        "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                     ),
                                     array (
                                         "column_name" => "attr2",
                                         "value" => "a0",
-                                        "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                     )
                                 )
                             )
@@ -1018,20 +1020,20 @@ class BatchGetRowTest extends SDKTestBase {
                         )
                     ),
                     "column_filter" => array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr1",
                                 "value" => 3,
-                                "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                             ),
                             array (
-                                "logical_operator" => LogicalOperatorConst::NOT,
+                                "logical_operator" => LogicalOperatorConst::CONST_NOT,
                                 "sub_conditions" => array (
                                     array (
                                         "column_name" => "attr2",
                                         "value" => "a9",
-                                        "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                        "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                     )
                                 )
                             )

--- a/src/OTS/Tests/BatchWriteRowTest.php
+++ b/src/OTS/Tests/BatchWriteRowTest.php
@@ -4,6 +4,8 @@ namespace Aliyun\OTS\Tests;
 
 use Aliyun\OTS;
 use Aliyun\OTS\RowExistenceExpectationConst;
+use Aliyun\OTS\ComparatorTypeConst;
+use Aliyun\OTS\LogicalOperatorConst;
 use Aliyun\OTS\ColumnTypeConst;
 use Aliyun\OTS\DirectionConst;
 
@@ -20,8 +22,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -67,7 +69,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => 'test9',
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -105,7 +107,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -116,7 +118,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
@@ -127,7 +129,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
@@ -138,7 +140,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -185,7 +187,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -196,7 +198,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
@@ -207,7 +209,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
@@ -218,7 +220,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -241,7 +243,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -254,7 +256,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
@@ -267,7 +269,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
@@ -280,7 +282,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -332,7 +334,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -343,7 +345,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
@@ -354,7 +356,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
@@ -365,7 +367,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -388,28 +390,28 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -450,7 +452,7 @@ class BatchWriteRowTest extends SDKTestBase {
         global $usedTables;
         for($i = 1; $i < 9; $i ++) {
             $put[] = array (
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -478,7 +480,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 9,
                                 "PK2" => "a9"
@@ -489,7 +491,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 10,
                                 "PK2" => "a10"
@@ -500,7 +502,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 11,
                                 "PK2" => "a11"
@@ -511,7 +513,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 12,
                                 "PK2" => "a12"
@@ -525,7 +527,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     // //////添加多行插入 put_rows
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 5,
                                 "PK2" => "a5"
@@ -538,7 +540,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 6,
                                 "PK2" => "a6"
@@ -551,7 +553,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 7,
                                 "PK2" => "a7"
@@ -564,7 +566,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 8,
                                 "PK2" => "a8"
@@ -579,28 +581,28 @@ class BatchWriteRowTest extends SDKTestBase {
                     ),
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -613,7 +615,7 @@ class BatchWriteRowTest extends SDKTestBase {
         $getrow = $this->otsClient->batchWriteRow ($batchWrite1);
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 100,
             "inclusive_start_primary_key" => array (
@@ -654,7 +656,7 @@ class BatchWriteRowTest extends SDKTestBase {
         global $usedTables;
         for($i = 1; $i < 1000; $i ++) {
             $a[] = array (
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -673,7 +675,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => $a,
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 5,
                                 "PK2" => "a5"
@@ -690,7 +692,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 6,
                                 "PK2" => "a6"
@@ -707,7 +709,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 7,
                                 "PK2" => "a7"
@@ -724,7 +726,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 8,
                                 "PK2" => "a8"
@@ -743,28 +745,28 @@ class BatchWriteRowTest extends SDKTestBase {
                     ),
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 2,
                                 "PK2" => "a2"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 3,
                                 "PK2" => "a3"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 4,
                                 "PK2" => "a4"
@@ -793,8 +795,8 @@ class BatchWriteRowTest extends SDKTestBase {
                 "table_meta" => array (
                     "table_name" => "test" . $i,
                     "primary_key_schema" => array (
-                        "PK1" => ColumnTypeConst::INTEGER,
-                        "PK2" => ColumnTypeConst::STRING
+                        "PK1" => ColumnTypeConst::CONST_INTEGER,
+                        "PK2" => ColumnTypeConst::CONST_STRING
                     )
                 ),
                 "reserved_throughput" => array (
@@ -813,7 +815,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => 'test1',
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -829,7 +831,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => 'test2',
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -845,7 +847,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => 'test3',
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -861,7 +863,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => 'test4',
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 1,
                                 "PK2" => "a1"
@@ -914,7 +916,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 9,
                                 "PK2" => "a9"
@@ -925,7 +927,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 10,
                                 "PK2" => "a10"
@@ -939,7 +941,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     // //////添加多行插入 put_rows
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+                            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                             "primary_key" => array (
                                 "PK1" => 510,
                                 "PK2" => "a510"
@@ -952,7 +954,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 6,
                                 "PK2" => "a6"
@@ -967,14 +969,14 @@ class BatchWriteRowTest extends SDKTestBase {
                     ),
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 11,
                                 "PK2" => "a11"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 12,
                                 "PK2" => "a12"
@@ -1028,7 +1030,7 @@ class BatchWriteRowTest extends SDKTestBase {
         foreach ($pkOfRows as $pk) {
             $this->otsClient->deleteRow (array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => $pk
             ));
         }
@@ -1039,7 +1041,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 9,
                                 "PK2" => "a9"
@@ -1050,7 +1052,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 10,
                                 "PK2" => "a10"
@@ -1064,7 +1066,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     // //////添加多行插入 put_rows
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+                            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                             "primary_key" => array (
                                 "PK1" => 510,
                                 "PK2" => "a510"
@@ -1077,7 +1079,7 @@ class BatchWriteRowTest extends SDKTestBase {
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+                            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                             "primary_key" => array (
                                 "PK1" => 6,
                                 "PK2" => "a6"
@@ -1092,14 +1094,14 @@ class BatchWriteRowTest extends SDKTestBase {
                     ),
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 11,
                                 "PK2" => "a11"
                             )
                         ),
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 12,
                                 "PK2" => "a12"
@@ -1132,8 +1134,8 @@ class BatchWriteRowTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[1],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::INTEGER,
-                    "PK2" => ColumnTypeConst::STRING
+                    "PK1" => ColumnTypeConst::CONST_INTEGER,
+                    "PK2" => ColumnTypeConst::CONST_STRING
                 )
             ),
             "reserved_throughput" => array (
@@ -1151,7 +1153,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[0],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 9,
                                 "PK2" => "a9"
@@ -1165,7 +1167,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     // //////添加多行插入 put_rows
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+                            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                             "primary_key" => array (
                                 "PK1" => 510,
                                 "PK2" => "a510"
@@ -1180,7 +1182,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     ),
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 11,
                                 "PK2" => "a11"
@@ -1192,7 +1194,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_name" => $usedTables[1],
                     "put_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 9,
                                 "PK2" => "a9"
@@ -1206,7 +1208,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     // //////添加多行插入 put_rows
                     "update_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+                            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                             "primary_key" => array (
                                 "PK1" => 510,
                                 "PK2" => "a510"
@@ -1221,7 +1223,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     ),
                     "delete_rows" => array (
                         array (
-                            "condition" => RowExistenceExpectationConst::IGNORE,
+                            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                             "primary_key" => array (
                                 "PK1" => 11,
                                 "PK2" => "a11"
@@ -1255,7 +1257,7 @@ class BatchWriteRowTest extends SDKTestBase {
                 "table_name" => 'test' . $i,
                 "put_rows" => array (
                     array (
-                        "condition" => RowExistenceExpectationConst::IGNORE,
+                        "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                         "primary_key" => array (
                             "PK1" => 1,
                             "PK2" => "a1"
@@ -1293,8 +1295,8 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_meta" => array (
                         "table_name" => $usedTables[$i],
                         "primary_key_schema" => array (
-                            "PK1" => ColumnTypeConst::INTEGER,
-                            "PK2" => ColumnTypeConst::STRING
+                            "PK1" => ColumnTypeConst::CONST_INTEGER,
+                            "PK2" => ColumnTypeConst::CONST_STRING
                         )
                     ),
                     "reserved_throughput" => array (
@@ -1310,7 +1312,7 @@ class BatchWriteRowTest extends SDKTestBase {
             for($k = 1; $k < 100; ++ $k) {
                 $putdata = array (
                     "table_name" => $usedTables[$i],
-                    "condition" => RowExistenceExpectationConst::IGNORE,
+                    "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                     "primary_key" => array (
                         "PK1" => $k,
                         "PK2" => "a" . $k
@@ -1334,11 +1336,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
                                     "column_name" => "attr1",
                                     "value" => 19,
-                                    "comparator" => ComparatorTypeConst::EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1355,11 +1357,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "update_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                                 "column_filter" => array (
                                     "column_name" => "attr1",
                                     "value" => 99,
-                                    "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1377,11 +1379,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "delete_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
                                     "column_name" => "attr2",
                                     "value" => "ab",
-                                    "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1456,8 +1458,8 @@ class BatchWriteRowTest extends SDKTestBase {
                 "table_meta" => array (
                     "table_name" => $usedTables[$i],
                     "primary_key_schema" => array (
-                        "PK1" => ColumnTypeConst::INTEGER,
-                        "PK2" => ColumnTypeConst::STRING
+                        "PK1" => ColumnTypeConst::CONST_INTEGER,
+                        "PK2" => ColumnTypeConst::CONST_STRING
                     )
                 ),
                 "reserved_throughput" => array (
@@ -1472,7 +1474,7 @@ class BatchWriteRowTest extends SDKTestBase {
             for($k = 1; $k < 100; ++ $k) {
                 $putdata = array (
                     "table_name" => $usedTables[$i],
-                    "condition" => RowExistenceExpectationConst::IGNORE,
+                    "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                     "primary_key" => array (
                         "PK1" => $k,
                         "PK2" => "a" . $k
@@ -1495,14 +1497,14 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::NOT,
+                                    "logical_operator" => LogicalOperatorConst::CONST_NOT,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 19,
-                                            "comparator" => ComparatorTypeConst::NOT_EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_NOT_EQUAL
                                         )
                                     )
                                 )
@@ -1521,27 +1523,27 @@ class BatchWriteRowTest extends SDKTestBase {
                     "update_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::AND,
+                                    "logical_operator" => LogicalOperatorConst::CONST_AND,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 99,
-                                            "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                         ),
                                         array (
-                                            "logical_operator" => LogicalOperatorConst::OR,
+                                            "logical_operator" => LogicalOperatorConst::CONST_OR,
                                             "sub_conditions" => array (
                                                 array (
                                                     "column_name" => "attr2",
                                                     "value" => "aa",
-                                                    "comparator" => ComparatorTypeConst::EQUAL
+                                                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                                                 ),
                                                 array (
                                                     "column_name" => "attr2",
                                                     "value" => "ddddd",
-                                                    "comparator" => ComparatorTypeConst::EQUAL
+                                                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                                                 )
                                             )
                                         )
@@ -1563,11 +1565,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "delete_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
                                     "column_name" => "attr2",
                                     "value" => "ab",
-                                    "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1639,8 +1641,8 @@ class BatchWriteRowTest extends SDKTestBase {
                     "table_meta" => array (
                         "table_name" => $usedTables[$i],
                         "primary_key_schema" => array (
-                            "PK1" => ColumnTypeConst::INTEGER,
-                            "PK2" => ColumnTypeConst::STRING
+                            "PK1" => ColumnTypeConst::CONST_INTEGER,
+                            "PK2" => ColumnTypeConst::CONST_STRING
                         )
                     ),
                     "reserved_throughput" => array (
@@ -1656,7 +1658,7 @@ class BatchWriteRowTest extends SDKTestBase {
             for($k = 1; $k < 100; ++ $k) {
                 $putdata = array (
                     "table_name" => $usedTables[$i],
-                    "condition" => RowExistenceExpectationConst::IGNORE,
+                    "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                     "primary_key" => array (
                         "PK1" => $k,
                         "PK2" => "a" . $k
@@ -1679,11 +1681,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
                                     "column_name" => "attr1",
                                     "value" => 19,
-                                    "comparator" => ComparatorTypeConst::EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1700,11 +1702,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "update_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                                 "column_filter" => array (
                                     "column_name" => "attr1",
                                     "value" => 99,
-                                    "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1722,11 +1724,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "delete_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
                                     "column_name" => "attr2",
                                     "value" => "ab",
-                                    "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -1741,7 +1743,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE
                             ),
                             "primary_key" => array (
                                 "PK1" => 119,
@@ -1757,19 +1759,19 @@ class BatchWriteRowTest extends SDKTestBase {
                     "update_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::AND,
+                                    "logical_operator" => LogicalOperatorConst::CONST_AND,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 10,
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         ),
                                         array (
                                             "column_name" => "attr2",
                                             "value" => "aa",
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         )
                                     )
                                 )
@@ -1789,19 +1791,19 @@ class BatchWriteRowTest extends SDKTestBase {
                     "delete_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::OR,
+                                    "logical_operator" => LogicalOperatorConst::CONST_OR,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 11,
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         ),
                                         array (
                                             "column_name" => "attr2",
                                             "value" => "aabbb",
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         )
                                     )
                                 )
@@ -1921,8 +1923,8 @@ class BatchWriteRowTest extends SDKTestBase {
                 "table_meta" => array (
                     "table_name" => $usedTables[$i],
                     "primary_key_schema" => array (
-                        "PK1" => ColumnTypeConst::INTEGER,
-                        "PK2" => ColumnTypeConst::STRING
+                        "PK1" => ColumnTypeConst::CONST_INTEGER,
+                        "PK2" => ColumnTypeConst::CONST_STRING
                     )
                 ),
                 "reserved_throughput" => array (
@@ -1937,7 +1939,7 @@ class BatchWriteRowTest extends SDKTestBase {
             for($k = 1; $k < 100; ++ $k) {
                 $putdata = array (
                     "table_name" => $usedTables[$i],
-                    "condition" => RowExistenceExpectationConst::IGNORE,
+                    "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                     "primary_key" => array (
                         "PK1" => $k,
                         "PK2" => "a" . $k
@@ -1960,14 +1962,14 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::NOT,
+                                    "logical_operator" => LogicalOperatorConst::CONST_NOT,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 19,
-                                            "comparator" => ComparatorTypeConst::NOT_EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_NOT_EQUAL
                                         )
                                     )
                                 )
@@ -1986,27 +1988,27 @@ class BatchWriteRowTest extends SDKTestBase {
                     "update_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::AND,
+                                    "logical_operator" => LogicalOperatorConst::CONST_AND,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 99,
-                                            "comparator" => ComparatorTypeConst::GREATER_EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_GREATER_EQUAL
                                         ),
                                         array (
-                                            "logical_operator" => LogicalOperatorConst::OR,
+                                            "logical_operator" => LogicalOperatorConst::CONST_OR,
                                             "sub_conditions" => array (
                                                 array (
                                                     "column_name" => "attr2",
                                                     "value" => "aa",
-                                                    "comparator" => ComparatorTypeConst::EQUAL
+                                                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                                                 ),
                                                 array (
                                                     "column_name" => "attr2",
                                                     "value" => "ddddd",
-                                                    "comparator" => ComparatorTypeConst::EQUAL
+                                                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                                                 )
                                             )
                                         )
@@ -2028,11 +2030,11 @@ class BatchWriteRowTest extends SDKTestBase {
                     "delete_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
                                     "column_name" => "attr2",
                                     "value" => "ab",
-                                    "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                    "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                                 )
                             ),
                             "primary_key" => array (
@@ -2047,7 +2049,7 @@ class BatchWriteRowTest extends SDKTestBase {
                     "put_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE
                             ),
                             "primary_key" => array (
                                 "PK1" => 119,
@@ -2063,19 +2065,19 @@ class BatchWriteRowTest extends SDKTestBase {
                     "update_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::AND,
+                                    "logical_operator" => LogicalOperatorConst::CONST_AND,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 10,
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         ),
                                         array (
                                             "column_name" => "attr2",
                                             "value" => "aa",
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         )
                                     )
                                 )
@@ -2095,19 +2097,19 @@ class BatchWriteRowTest extends SDKTestBase {
                     "delete_rows" => array (
                         array (
                             "condition" => array (
-                                "row_existence" => RowExistenceExpectationConst::IGNORE,
+                                "row_existence" => RowExistenceExpectationConst::CONST_IGNORE,
                                 "column_filter" => array (
-                                    "logical_operator" => LogicalOperatorConst::OR,
+                                    "logical_operator" => LogicalOperatorConst::CONST_OR,
                                     "sub_conditions" => array (
                                         array (
                                             "column_name" => "attr1",
                                             "value" => 11,
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         ),
                                         array (
                                             "column_name" => "attr2",
                                             "value" => "aabbb",
-                                            "comparator" => ComparatorTypeConst::EQUAL
+                                            "comparator" => ComparatorTypeConst::CONST_EQUAL
                                         )
                                     )
                                 )

--- a/src/OTS/Tests/CreateTableTest.php
+++ b/src/OTS/Tests/CreateTableTest.php
@@ -26,10 +26,10 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "myTable",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -50,10 +50,10 @@ class CreateTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => "myTable",
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::STRING,
-                "PK2" => ColumnTypeConst::INTEGER,
-                "PK3" => ColumnTypeConst::STRING,
-                "PK4" => ColumnTypeConst::INTEGER
+                "PK1" => ColumnTypeConst::CONST_STRING,
+                "PK2" => ColumnTypeConst::CONST_INTEGER,
+                "PK3" => ColumnTypeConst::CONST_STRING,
+                "PK4" => ColumnTypeConst::CONST_INTEGER
             )
         );
         $table_meta = $this->otsClient->describeTable ($table_name);
@@ -70,10 +70,10 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -101,10 +101,10 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "testU+0053",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -136,10 +136,10 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $name,
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -193,7 +193,7 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "test3",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING
+                    "PK1" => ColumnTypeConst::CONST_STRING
                 )
             ),
             "reserved_throughput" => array (
@@ -208,7 +208,7 @@ class CreateTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => $tablebody['table_meta']['table_name'],
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::STRING
+                "PK1" => ColumnTypeConst::CONST_STRING
             )
         );
         $table_meta = $this->otsClient->describeTable ($tablename);
@@ -224,10 +224,10 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "test4",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -243,10 +243,10 @@ class CreateTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => $tablebody['table_meta']['table_name'],
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::STRING,
-                "PK2" => ColumnTypeConst::INTEGER,
-                "PK3" => ColumnTypeConst::STRING,
-                "PK4" => ColumnTypeConst::INTEGER
+                "PK1" => ColumnTypeConst::CONST_STRING,
+                "PK2" => ColumnTypeConst::CONST_INTEGER,
+                "PK3" => ColumnTypeConst::CONST_STRING,
+                "PK4" => ColumnTypeConst::CONST_INTEGER
             )
         );
         $table_meta = $this->otsClient->describeTable ($tablename);
@@ -260,7 +260,7 @@ class CreateTableTest extends SDKTestBase {
     public function testTooMuchPKInSchema() {
         $key = array ();
         for($i = 1; $i < 1001; $i ++) {
-            $key['a' . $i] = ColumnTypeConst::INTEGER;
+            $key['a' . $i] = ColumnTypeConst::CONST_INTEGER;
         }
         // print_r($key);die;
         $tablebody = array (
@@ -293,8 +293,8 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "test5",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::INTEGER,
-                    "PK2" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_INTEGER,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -309,8 +309,8 @@ class CreateTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => $tablebody['table_meta']['table_name'],
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::INTEGER,
-                "PK2" => ColumnTypeConst::INTEGER
+                "PK1" => ColumnTypeConst::CONST_INTEGER,
+                "PK2" => ColumnTypeConst::CONST_INTEGER
             )
         );
         $table_meta = $this->otsClient->describeTable ($tablename);
@@ -326,8 +326,8 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "test5",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::STRING
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_STRING
                 )
             ),
             "reserved_throughput" => array (
@@ -342,8 +342,8 @@ class CreateTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => $tablebody['table_meta']['table_name'],
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::STRING,
-                "PK2" => ColumnTypeConst::STRING
+                "PK1" => ColumnTypeConst::CONST_STRING,
+                "PK2" => ColumnTypeConst::CONST_STRING
             )
         );
         $table_meta = $this->otsClient->describeTable ($tablename);
@@ -360,8 +360,8 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "test",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::DOUBLE,
-                    "PK2" => ColumnTypeConst::DOUBLE
+                    "PK1" => ColumnTypeConst::CONST_DOUBLE,
+                    "PK2" => ColumnTypeConst::CONST_DOUBLE
                 )
             ),
             "reserved_throughput" => array (
@@ -375,8 +375,8 @@ class CreateTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "test",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::BOOLEAN,
-                    "PK2" => ColumnTypeConst::BOOLEAN
+                    "PK1" => ColumnTypeConst::CONST_BOOLEAN,
+                    "PK2" => ColumnTypeConst::CONST_BOOLEAN
                 )
             ),
             "reserved_throughput" => array (

--- a/src/OTS/Tests/DeleteRowTest.php
+++ b/src/OTS/Tests/DeleteRowTest.php
@@ -4,6 +4,7 @@ namespace Aliyun\OTS\Tests;
 
 use Aliyun\OTS;
 use Aliyun\OTS\ColumnTypeConst;
+use Aliyun\OTS\ComparatorTypeConst;
 use Aliyun\OTS\RowExistenceExpectationConst;
 
 require __DIR__ . "/TestBase.php";
@@ -18,8 +19,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -41,7 +42,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $deleterow = array (
             "table_name" => "",
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -65,7 +66,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $deleterow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "aaa",
                 "PK2" => "cc",
@@ -92,7 +93,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -105,7 +106,7 @@ class DeleteRowTest extends SDKTestBase {
         $this->otsClient->putRow ($tablename);
         $deleterow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
             "primary_key" => array (
                 "PK1" => 2,
                 "PK2" => "a2"
@@ -129,7 +130,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -142,7 +143,7 @@ class DeleteRowTest extends SDKTestBase {
         $this->otsClient->putRow ($tablename);
         $deleterow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -173,7 +174,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $deleterow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_NOT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -195,7 +196,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -208,7 +209,7 @@ class DeleteRowTest extends SDKTestBase {
         $this->otsClient->putRow ($tablename);
         $deleterow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_NOT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -230,7 +231,7 @@ class DeleteRowTest extends SDKTestBase {
         global $usedTables;
         $put_query = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -245,11 +246,11 @@ class DeleteRowTest extends SDKTestBase {
         $delete_query = array (
             "table_name" => $usedTables[0],
             "condition" => array (
-                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                 "column_filter" => array (
                     "column_name" => "attr1",
                     "value" => "asds",
-                    "comparator" => ComparatorTypeConst::EQUAL
+                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                 )
             ),
             "primary_key" => array (
@@ -275,7 +276,7 @@ class DeleteRowTest extends SDKTestBase {
         
         $put_query2 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -290,11 +291,11 @@ class DeleteRowTest extends SDKTestBase {
         $delete_query2 = array (
             "table_name" => $usedTables[0],
             "condition" => array (
-                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                 "column_filter" => array (
                     "column_name" => "att1",
                     "value" => "asdsddd",
-                    "comparator" => ComparatorTypeConst::EQUAL
+                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                 )
             ),
             "primary_key" => array (

--- a/src/OTS/Tests/DeleteTableTest.php
+++ b/src/OTS/Tests/DeleteTableTest.php
@@ -26,10 +26,10 @@ class DeleteTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[0],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (

--- a/src/OTS/Tests/DescribeTableTest.php
+++ b/src/OTS/Tests/DescribeTableTest.php
@@ -30,8 +30,8 @@ class DescribeTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[0],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::INTEGER,
-                    "PK2" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_INTEGER,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -46,8 +46,8 @@ class DescribeTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => $tablebody['table_meta']['table_name'],
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::INTEGER,
-                "PK2" => ColumnTypeConst::INTEGER
+                "PK1" => ColumnTypeConst::CONST_INTEGER,
+                "PK2" => ColumnTypeConst::CONST_INTEGER
             )
         );
         $table_meta = $this->otsClient->describeTable ($tablename);
@@ -65,8 +65,8 @@ class DescribeTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[0],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::STRING
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_STRING
                 )
             ),
             "reserved_throughput" => array (
@@ -81,8 +81,8 @@ class DescribeTableTest extends SDKTestBase {
         $teturn = array (
             "table_name" => $tablebody['table_meta']['table_name'],
             "primary_key_schema" => array (
-                "PK1" => ColumnTypeConst::STRING,
-                "PK2" => ColumnTypeConst::STRING
+                "PK1" => ColumnTypeConst::CONST_STRING,
+                "PK2" => ColumnTypeConst::CONST_STRING
             )
         );
         $table_meta = $this->otsClient->describeTable ($tablename);
@@ -98,10 +98,10 @@ class DescribeTableTest extends SDKTestBase {
         global $usedTables;
         
         $invalidTypes = array (
-            ColumnTypeConst::DOUBLE,
-            ColumnTypeConst::BOOLEAN,
-            ColumnTypeConst::INF_MIN,
-            ColumnTypeConst::INF_MAX
+            ColumnTypeConst::CONST_DOUBLE,
+            ColumnTypeConst::CONST_BOOLEAN,
+            ColumnTypeConst::CONST_INF_MIN,
+            ColumnTypeConst::CONST_INF_MAX
         );
         
         foreach ($invalidTypes as $type) {

--- a/src/OTS/Tests/GetRangeTest.php
+++ b/src/OTS/Tests/GetRangeTest.php
@@ -22,8 +22,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -38,7 +38,7 @@ SDKTestBase::createInitialTable (array (
         "table_meta" => array (
                 "table_name" => $usedTables[1],
                 "primary_key_schema" => array (
-                        "PK1" => ColumnTypeConst::INTEGER
+                        "PK1" => ColumnTypeConst::CONST_INTEGER
                 )
         ),
         "reserved_throughput" => array (
@@ -53,7 +53,7 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[2],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER
+            "PK1" => ColumnTypeConst::CONST_INTEGER
         )
     ),
     "reserved_throughput" => array (
@@ -68,10 +68,10 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[3],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING,
-            "PK3" => ColumnTypeConst::INTEGER,
-            "PK4" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING,
+            "PK3" => ColumnTypeConst::CONST_INTEGER,
+            "PK4" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -96,7 +96,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -111,7 +111,7 @@ class GetRangeTest extends SDKTestBase {
         
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => 1,
@@ -159,7 +159,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -173,7 +173,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::BACKWARD,
+            "direction" => DirectionConst::CONST_BACKWARD,
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => 2,
@@ -222,7 +222,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -236,15 +236,15 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MIN
+                    'type' => ColumnTypeConst::CONST_INF_MIN
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MIN
+                    'type' => ColumnTypeConst::CONST_INF_MIN
                 )
             ),
             "exclusive_end_primary_key" => array (
@@ -289,7 +289,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -303,14 +303,14 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::BACKWARD,
+            "direction" => DirectionConst::CONST_BACKWARD,
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             ),
             "exclusive_end_primary_key" => array (
@@ -355,7 +355,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[3],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i,
@@ -373,7 +373,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[3],
-            "direction" => DirectionConst::BACKWARD,
+            "direction" => DirectionConst::CONST_BACKWARD,
             "columns_to_get" => array (
                 "att1",
                 "att2",
@@ -383,16 +383,16 @@ class GetRangeTest extends SDKTestBase {
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK3" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK4" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             ),
             "exclusive_end_primary_key" => array (
@@ -435,7 +435,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[3],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i,
@@ -453,21 +453,21 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[3],
-            "direction" => DirectionConst::BACKWARD,
+            "direction" => DirectionConst::CONST_BACKWARD,
             "columns_to_get" => array (),
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK3" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK4" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             ),
             "exclusive_end_primary_key" => array (
@@ -521,7 +521,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[3],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i,
@@ -539,7 +539,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[3],
-            "direction" => DirectionConst::BACKWARD,
+            "direction" => DirectionConst::CONST_BACKWARD,
             "columns_to_get" => array (
                 "PK1",
                 "PK2",
@@ -549,16 +549,16 @@ class GetRangeTest extends SDKTestBase {
             "limit" => 10,
             "inclusive_start_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK3" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK4" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             ),
             "exclusive_end_primary_key" => array (
@@ -604,7 +604,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -621,7 +621,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => $a,
             "limit" => 10,
             "inclusive_start_primary_key" => array (
@@ -647,7 +647,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 3; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -661,7 +661,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (
                 "att1",
                 "att1"
@@ -694,7 +694,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 21; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -707,7 +707,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 10,
             "inclusive_start_primary_key" => array (
@@ -716,10 +716,10 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -756,7 +756,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 2; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[0],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i,
                     "PK2" => "a" . $i
@@ -769,7 +769,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[0],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 1,
             "inclusive_start_primary_key" => array (
@@ -778,10 +778,10 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 ),
                 "PK2" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -807,10 +807,10 @@ class GetRangeTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -838,10 +838,10 @@ class GetRangeTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => "testU+0053",
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             "reserved_throughput" => array (
@@ -870,7 +870,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 5001; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[1],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i
                 ),
@@ -880,7 +880,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[1],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -888,7 +888,7 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -906,7 +906,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 5002; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[1],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i
                 ),
@@ -916,7 +916,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[1],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -924,7 +924,7 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -942,7 +942,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 15001; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[1],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i
                 ),
@@ -952,7 +952,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[1],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -960,14 +960,14 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
         $this->otsClient->getRange ($getRange);
         $getRange1 = array (
             "table_name" => $usedTables[1],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -975,14 +975,14 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
         $this->otsClient->getRange ($getRange1);
         $getRange2 = array (
             "table_name" => $usedTables[1],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -990,14 +990,14 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
         $this->otsClient->getRange ($getRange2);
         $getRange3 = array (
             "table_name" => $usedTables[1],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -1005,7 +1005,7 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -1023,7 +1023,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 10001; $i ++) {
             $tablename = array (
                 "table_name" => $usedTables[2],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i
                 ),
@@ -1033,7 +1033,7 @@ class GetRangeTest extends SDKTestBase {
         }
         $getRange = array (
             "table_name" => $usedTables[2],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -1041,7 +1041,7 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -1050,7 +1050,7 @@ class GetRangeTest extends SDKTestBase {
         // $this->assertEquals($tables['next_start_primary_key'], $primary);
         $getRange1 = array (
             "table_name" => $usedTables[2],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (),
             "limit" => 5000,
             "inclusive_start_primary_key" => array (
@@ -1058,7 +1058,7 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             )
         );
@@ -1074,7 +1074,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 10001; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[2],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i
                 ),
@@ -1088,7 +1088,7 @@ class GetRangeTest extends SDKTestBase {
         
         $getRange = array (
             "table_name" => $usedTables[2],
-            "direction" => DirectionConst::FORWARD,
+            "direction" => DirectionConst::CONST_FORWARD,
             "columns_to_get" => array (
                 "att1",
                 "att2"
@@ -1099,21 +1099,21 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             ),
             "column_filter" => array (
-                "logical_operator" => LogicalOperatorConst::AND,
+                "logical_operator" => LogicalOperatorConst::CONST_AND,
                 "sub_conditions" => array (
                     array (
                         "column_name" => "attr1",
                         "value" => 10,
-                        "comparator" => ComparatorTypeConst::GREATER_THAN
+                        "comparator" => ComparatorTypeConst::CONST_GREATER_THAN
                     ),
                     array (
                         "column_name" => "attr2",
                         "value" => "att10001",
-                        "comparator" => ComparatorTypeConst::LESS_THAN
+                        "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                     )
                 )
             )
@@ -1130,7 +1130,7 @@ class GetRangeTest extends SDKTestBase {
         for($i = 1; $i < 10001; $i ++) {
             $putdata = array (
                 "table_name" => $usedTables[2],
-                "condition" => RowExistenceExpectationConst::IGNORE,
+                "condition" => RowExistenceExpectationConst::CONST_IGNORE,
                 "primary_key" => array (
                     "PK1" => $i
                 ),
@@ -1144,7 +1144,7 @@ class GetRangeTest extends SDKTestBase {
         
         $getRange = array (
             "table_name" => $usedTables[2],
-            "direction" => DirectionConst::BACKWARD,
+            "direction" => DirectionConst::CONST_BACKWARD,
             "columns_to_get" => array (
                 "att1",
                 "att2"
@@ -1155,39 +1155,39 @@ class GetRangeTest extends SDKTestBase {
             ),
             "exclusive_end_primary_key" => array (
                 "PK1" => array (
-                    'type' => ColumnTypeConst::INF_MAX
+                    'type' => ColumnTypeConst::CONST_INF_MAX
                 )
             ),
             "column_filter" => array (
-                "logical_operator" => LogicalOperatorConst::OR,
+                "logical_operator" => LogicalOperatorConst::CONST_OR,
                 "sub_conditions" => array (
                     array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr1",
                                 "value" => 10,
-                                "comparator" => ComparatorTypeConst::GREATER_THAN
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_THAN
                             ),
                             array (
                                 "column_name" => "attr1",
                                 "value" => 20000,
-                                "comparator" => ComparatorTypeConst::LESS_THAN
+                                "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                             )
                         )
                     ),
                     array (
-                        "logical_operator" => LogicalOperatorConst::AND,
+                        "logical_operator" => LogicalOperatorConst::CONST_AND,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr2",
                                 "value" => "att1001",
-                                "comparator" => ComparatorTypeConst::GREATER_THAN
+                                "comparator" => ComparatorTypeConst::CONST_GREATER_THAN
                             ),
                             array (
                                 "column_name" => "attr2",
                                 "value" => "att1002",
-                                "comparator" => ComparatorTypeConst::LESS_EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_LESS_EQUAL
                             )
                         )
                     )

--- a/src/OTS/Tests/GetRowTest.php
+++ b/src/OTS/Tests/GetRowTest.php
@@ -4,6 +4,8 @@ namespace Aliyun\OTS\Tests;
 
 use Aliyun\OTS;
 use Aliyun\OTS\RowExistenceExpectationConst;
+use Aliyun\OTS\LogicalOperatorConst;
+use Aliyun\OTS\ComparatorTypeConst;
 use Aliyun\OTS\ColumnTypeConst;
 
 require __DIR__ . "/TestBase.php";
@@ -18,10 +20,10 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::STRING,
-            "PK2" => ColumnTypeConst::INTEGER,
-            "PK3" => ColumnTypeConst::STRING,
-            "PK4" => ColumnTypeConst::INTEGER
+            "PK1" => ColumnTypeConst::CONST_STRING,
+            "PK2" => ColumnTypeConst::CONST_INTEGER,
+            "PK3" => ColumnTypeConst::CONST_STRING,
+            "PK4" => ColumnTypeConst::CONST_INTEGER
         )
     ),
     "reserved_throughput" => array (
@@ -35,7 +37,7 @@ SDKTestBase::waitForTableReady ();
 
 SDKTestBase::putInitialData (array (
     "table_name" => $usedTables[0],
-    "condition" => RowExistenceExpectationConst::IGNORE,
+    "condition" => RowExistenceExpectationConst::CONST_IGNORE,
     "primary_key" => array (
         "PK1" => "a1",
         "PK2" => 1,
@@ -76,7 +78,7 @@ class GetRowTest extends SDKTestBase {
         );
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -118,7 +120,7 @@ class GetRowTest extends SDKTestBase {
         );
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -163,7 +165,7 @@ class GetRowTest extends SDKTestBase {
         );
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -207,7 +209,7 @@ class GetRowTest extends SDKTestBase {
         );
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -276,7 +278,7 @@ class GetRowTest extends SDKTestBase {
         );
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -306,7 +308,7 @@ class GetRowTest extends SDKTestBase {
         
         $putdata1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -322,7 +324,7 @@ class GetRowTest extends SDKTestBase {
         );
         $putdata2 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a2",
                 "PK2" => 2,
@@ -353,17 +355,17 @@ class GetRowTest extends SDKTestBase {
                 "PK4"
             ),
             "column_filter" => array (
-                "logical_operator" => LogicalOperatorConst::AND,
+                "logical_operator" => LogicalOperatorConst::CONST_AND,
                 "sub_conditions" => array (
                     array (
                         "column_name" => "attr1",
                         "value" => 1,
-                        "comparator" => ComparatorTypeConst::GREATER_THAN
+                        "comparator" => ComparatorTypeConst::CONST_GREATER_THAN
                     ),
                     array (
                         "column_name" => "attr4",
                         "value" => 30,
-                        "comparator" => ComparatorTypeConst::LESS_THAN
+                        "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                     )
                 )
             )
@@ -383,7 +385,7 @@ class GetRowTest extends SDKTestBase {
         
         $putdata1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -399,7 +401,7 @@ class GetRowTest extends SDKTestBase {
         );
         $putdata2 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "aa2",
                 "PK2" => 2,
@@ -430,12 +432,12 @@ class GetRowTest extends SDKTestBase {
                 "attr4"
             ),
             "column_filter" => array (
-                "logical_operator" => LogicalOperatorConst::NOT,
+                "logical_operator" => LogicalOperatorConst::CONST_NOT,
                 "sub_conditions" => array (
                     array (
                         "column_name" => "attr4",
                         "value" => 22,
-                        "comparator" => ComparatorTypeConst::NOT_EQUAL
+                        "comparator" => ComparatorTypeConst::CONST_NOT_EQUAL
                     )
                 )
             )
@@ -456,7 +458,7 @@ class GetRowTest extends SDKTestBase {
         
         $putdata1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -472,7 +474,7 @@ class GetRowTest extends SDKTestBase {
         );
         $putdata2 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a2",
                 "PK2" => 2,
@@ -503,18 +505,18 @@ class GetRowTest extends SDKTestBase {
                 "PK4"
             ),
             "column_filter" => array (
-                "logical_operator" => LogicalOperatorConst::AND,
+                "logical_operator" => LogicalOperatorConst::CONST_AND,
                 "sub_conditions" => array (
                     array (
                         "column_name" => "attr55",
                         "value" => 1,
-                        "comparator" => ComparatorTypeConst::GREATER_THAN,
+                        "comparator" => ComparatorTypeConst::CONST_GREATER_THAN,
                         "pass_if_missing" => false
                     ),
                     array (
                         "column_name" => "attr4",
                         "value" => 30,
-                        "comparator" => ComparatorTypeConst::LESS_THAN
+                        "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                     )
                 )
             )
@@ -532,7 +534,7 @@ class GetRowTest extends SDKTestBase {
         
         $putdata1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a1",
                 "PK2" => 1,
@@ -548,7 +550,7 @@ class GetRowTest extends SDKTestBase {
         );
         $putdata2 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => "a2",
                 "PK2" => 2,
@@ -579,30 +581,30 @@ class GetRowTest extends SDKTestBase {
                 "PK4"
             ),
             "column_filter" => array (
-                "logical_operator" => LogicalOperatorConst::AND,
+                "logical_operator" => LogicalOperatorConst::CONST_AND,
                 "sub_conditions" => array (
                     array (
                         "column_name" => "attr1",
                         "value" => 1,
-                        "comparator" => ComparatorTypeConst::GREATER_THAN
+                        "comparator" => ComparatorTypeConst::CONST_GREATER_THAN
                     ),
                     array (
                         "column_name" => "attr4",
                         "value" => 30,
-                        "comparator" => ComparatorTypeConst::LESS_THAN
+                        "comparator" => ComparatorTypeConst::CONST_LESS_THAN
                     ),
                     array (
-                        "logical_operator" => LogicalOperatorConst::OR,
+                        "logical_operator" => LogicalOperatorConst::CONST_OR,
                         "sub_conditions" => array (
                             array (
                                 "column_name" => "attr2",
                                 "value" => "aaaaa",
-                                "comparator" => ComparatorTypeConst::EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_EQUAL
                             ),
                             array (
                                 "column_name" => "attr3",
                                 "value" => "tass",
-                                "comparator" => ComparatorTypeConst::EQUAL
+                                "comparator" => ComparatorTypeConst::CONST_EQUAL
                             )
                         )
                     )

--- a/src/OTS/Tests/ListTableTest.php
+++ b/src/OTS/Tests/ListTableTest.php
@@ -36,10 +36,10 @@ class listTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[0],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             
@@ -67,10 +67,10 @@ class listTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[0],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             
@@ -85,10 +85,10 @@ class listTableTest extends SDKTestBase {
             "table_meta" => array (
                 "table_name" => $usedTables[1],
                 "primary_key_schema" => array (
-                    "PK1" => ColumnTypeConst::STRING,
-                    "PK2" => ColumnTypeConst::INTEGER,
-                    "PK3" => ColumnTypeConst::STRING,
-                    "PK4" => ColumnTypeConst::INTEGER
+                    "PK1" => ColumnTypeConst::CONST_STRING,
+                    "PK2" => ColumnTypeConst::CONST_INTEGER,
+                    "PK3" => ColumnTypeConst::CONST_STRING,
+                    "PK4" => ColumnTypeConst::CONST_INTEGER
                 )
             ),
             

--- a/src/OTS/Tests/PutRowTest.php
+++ b/src/OTS/Tests/PutRowTest.php
@@ -4,6 +4,7 @@ namespace Aliyun\OTS\Tests;
 
 use Aliyun\OTS;
 use Aliyun\OTS\ColumnTypeConst;
+use Aliyun\OTS\ComparatorTypeConst;
 use Aliyun\OTS\RowExistenceExpectationConst;
 
 require __DIR__ . "/TestBase.php";
@@ -19,8 +20,8 @@ SDKTestBase::createInitialTable ( array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING 
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING 
         ) 
     ),
     "reserved_throughput" => array (
@@ -34,8 +35,8 @@ SDKTestBase::createInitialTable ( array (
     "table_meta" => array (
         "table_name" => $usedTables[1],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING 
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING 
         ) 
     ),
     "reserved_throughput" => array (
@@ -56,7 +57,7 @@ class PutRowTest extends SDKTestBase {
     public function testTableNameOfZeroLength() {
         $tablename1 = array (
             "table_name" => "",
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1" 
@@ -76,7 +77,7 @@ class PutRowTest extends SDKTestBase {
         // die;
         $tablename2 = array (
             "table_name" => "testU+0053",
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1" 
@@ -108,7 +109,7 @@ class PutRowTest extends SDKTestBase {
         // ColumnNameOfZeroLength
         $tablename1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1" 
@@ -128,7 +129,7 @@ class PutRowTest extends SDKTestBase {
         // ColumnNameWithUnicode
         $tablename2 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1" 
@@ -152,7 +153,7 @@ class PutRowTest extends SDKTestBase {
         }
         $tablename3 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1" 
@@ -183,7 +184,7 @@ class PutRowTest extends SDKTestBase {
         }
         $tablename = array (
             "table_name" => $usedTables[1],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1" 
@@ -218,7 +219,7 @@ class PutRowTest extends SDKTestBase {
         // echo strlen($a);die;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 11,
                 "PK2" => "a11" 
@@ -258,7 +259,7 @@ class PutRowTest extends SDKTestBase {
         // echo strlen($a);die;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 12,
                 "PK2" => "a12" 
@@ -284,7 +285,7 @@ class PutRowTest extends SDKTestBase {
         }
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 13,
                 "PK2" => "a13" 
@@ -327,7 +328,7 @@ class PutRowTest extends SDKTestBase {
         // echo strlen($a);die;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 20,
                 "PK2" => "a20" 
@@ -357,7 +358,7 @@ class PutRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 30,
                 "PK2" => "a30" 
@@ -380,7 +381,7 @@ class PutRowTest extends SDKTestBase {
         
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 31,
                 "PK2" => "a31" 
@@ -417,7 +418,7 @@ class PutRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 40,
                 "PK2" => "a40" 
@@ -440,7 +441,7 @@ class PutRowTest extends SDKTestBase {
         
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 41,
                 "PK2" => "a41" 
@@ -476,7 +477,7 @@ class PutRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 50,
                 "PK2" => "a50" 
@@ -510,7 +511,7 @@ class PutRowTest extends SDKTestBase {
         global $usedTables;
         $request = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 50,
                 "PK2" => "a50" 
@@ -520,7 +521,7 @@ class PutRowTest extends SDKTestBase {
         
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_NOT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST,
             "primary_key" => array (
                 "PK1" => 50,
                 "PK2" => "a50" 
@@ -545,7 +546,7 @@ class PutRowTest extends SDKTestBase {
         
         $tablename1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_NOT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST,
             "primary_key" => array (
                 "PK1" => 50,
                 "PK2" => "a50" 
@@ -573,7 +574,7 @@ class PutRowTest extends SDKTestBase {
         global $usedTables;
         $delete_query = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 50,
                 "PK2" => "a50" 
@@ -583,7 +584,7 @@ class PutRowTest extends SDKTestBase {
         
         $put_query1 = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_NOT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST,
             "primary_key" => array (
                 "PK1" => 50,
                 "PK2" => "a50" 
@@ -598,11 +599,11 @@ class PutRowTest extends SDKTestBase {
         $put_query2 = array (
             "table_name" => $usedTables[0],
             "condition" => array (
-                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                 "column_filter" => array (
                     "column_name" => "attr1",
                     "value" => true,
-                    "comparator" => ComparatorTypeConst::EQUAL 
+                    "comparator" => ComparatorTypeConst::CONST_EQUAL 
                 ) 
             ),
             "primary_key" => array (
@@ -636,11 +637,11 @@ class PutRowTest extends SDKTestBase {
         $put_query3 = array (
             "table_name" => $usedTables[0],
             "condition" => array (
-                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                 "column_filter" => array (
                     "column_name" => "attr3",
                     "value" => true,
-                    "comparator" => ComparatorTypeConst::EQUAL 
+                    "comparator" => ComparatorTypeConst::CONST_EQUAL 
                 ) 
             ),
             "primary_key" => array (

--- a/src/OTS/Tests/TestConfig.php
+++ b/src/OTS/Tests/TestConfig.php
@@ -1,7 +1,7 @@
 <?php
 
 
-define('SDK_TEST_END_POINT', '');
-define('SDK_TEST_ACCESS_KEY_ID', '');
-define('SDK_TEST_ACCESS_KEY_SECRET', '');
-define('SDK_TEST_INSTANCE_NAME', '');
+define('SDK_TEST_END_POINT', 'http://bbq.cn-hangzhou.ots.aliyuncs.com');
+define('SDK_TEST_ACCESS_KEY_ID', 'LTAIuguL9hwrO0MD');
+define('SDK_TEST_ACCESS_KEY_SECRET', 'XY1tE14fdHNzSbtKXMAadvsyoNsT2n');
+define('SDK_TEST_INSTANCE_NAME', 'bbq');

--- a/src/OTS/Tests/TestConfig.php
+++ b/src/OTS/Tests/TestConfig.php
@@ -1,7 +1,7 @@
 <?php
 
 
-define('SDK_TEST_END_POINT', 'http://bbq.cn-hangzhou.ots.aliyuncs.com');
-define('SDK_TEST_ACCESS_KEY_ID', 'LTAIuguL9hwrO0MD');
-define('SDK_TEST_ACCESS_KEY_SECRET', 'XY1tE14fdHNzSbtKXMAadvsyoNsT2n');
-define('SDK_TEST_INSTANCE_NAME', 'bbq');
+define('SDK_TEST_END_POINT', '');
+define('SDK_TEST_ACCESS_KEY_ID', '');
+define('SDK_TEST_ACCESS_KEY_SECRET', '');
+define('SDK_TEST_INSTANCE_NAME', '');

--- a/src/OTS/Tests/UpdateRowTest.php
+++ b/src/OTS/Tests/UpdateRowTest.php
@@ -3,6 +3,7 @@
 namespace Aliyun\OTS\Tests;
 
 use Aliyun\OTS;
+use Aliyun\OTS\ComparatorTypeConst;
 use Aliyun\OTS\RowExistenceExpectationConst;
 use Aliyun\OTS\ColumnTypeConst;
 
@@ -18,8 +19,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -41,7 +42,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -78,7 +79,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -93,7 +94,7 @@ class UpdateRowTest extends SDKTestBase {
         $this->otsClient->putRow ($tablename);
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 1,
                 "PK2" => "a1"
@@ -130,7 +131,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 3,
                 "PK2" => "a3"
@@ -156,7 +157,7 @@ class UpdateRowTest extends SDKTestBase {
         
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 3,
                 "PK2" => "a3"
@@ -195,7 +196,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 3,
                 "PK2" => "a3"
@@ -228,7 +229,7 @@ class UpdateRowTest extends SDKTestBase {
         }
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 3,
                 "PK2" => "a3"
@@ -262,7 +263,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
             "primary_key" => array (
                 "PK1" => 30,
                 "PK2" => "a30"
@@ -292,7 +293,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $tablename = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 100,
                 "PK2" => "a100"
@@ -307,7 +308,7 @@ class UpdateRowTest extends SDKTestBase {
         $this->otsClient->putRow ($tablename);
         $updateRow = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::EXPECT_EXIST,
+            "condition" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
             "primary_key" => array (
                 "PK1" => 100,
                 "PK2" => "a100"
@@ -340,7 +341,7 @@ class UpdateRowTest extends SDKTestBase {
         global $usedTables;
         $put_query = array (
             "table_name" => $usedTables[0],
-            "condition" => RowExistenceExpectationConst::IGNORE,
+            "condition" => RowExistenceExpectationConst::CONST_IGNORE,
             "primary_key" => array (
                 "PK1" => 100,
                 "PK2" => "a100"
@@ -357,11 +358,11 @@ class UpdateRowTest extends SDKTestBase {
         $update_query = array (
             "table_name" => $usedTables[0],
             "condition" => array (
-                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                 "column_filter" => array (
                     "column_name" => "test1",
                     "value" => "name1",
-                    "comparator" => ComparatorTypeConst::EQUAL
+                    "comparator" => ComparatorTypeConst::CONST_EQUAL
                 )
             ),
             "primary_key" => array (
@@ -398,11 +399,11 @@ class UpdateRowTest extends SDKTestBase {
         $update_query2 = array (
             "table_name" => $usedTables[0],
             "condition" => array (
-                "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+                "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
                 "column_filter" => array (
                     "column_name" => "test1",
                     "value" => "name1",
-                    "comparator" => ComparatorTypeConst::NOT_EQUAL
+                    "comparator" => ComparatorTypeConst::CONST_NOT_EQUAL
                 )
             ),
             "primary_key" => array (

--- a/src/OTS/Tests/UpdateTableTest.php
+++ b/src/OTS/Tests/UpdateTableTest.php
@@ -19,8 +19,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[0],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -34,8 +34,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[1],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (
@@ -49,8 +49,8 @@ SDKTestBase::createInitialTable (array (
     "table_meta" => array (
         "table_name" => $usedTables[2],
         "primary_key_schema" => array (
-            "PK1" => ColumnTypeConst::INTEGER,
-            "PK2" => ColumnTypeConst::STRING
+            "PK1" => ColumnTypeConst::CONST_INTEGER,
+            "PK2" => ColumnTypeConst::CONST_STRING
         )
     ),
     "reserved_throughput" => array (

--- a/src/examples/BatchGetRow1.php
+++ b/src/examples/BatchGetRow1.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 1,
         'PK1' => 'Zhejiang'
@@ -47,7 +47,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 2,
         'PK1' => 'Jiangsu'
@@ -60,7 +60,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 3,
         'PK1' => 'Guangdong'

--- a/src/examples/BatchGetRow2.php
+++ b/src/examples/BatchGetRow2.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 1,
         'PK1' => 'Zhejiang'
@@ -47,7 +47,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 2,
         'PK1' => 'Jiangsu'
@@ -60,7 +60,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 3,
         'PK1' => 'Guangdong'

--- a/src/examples/BatchGetRow3.php
+++ b/src/examples/BatchGetRow3.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     'reserved_throughput' => array (
@@ -33,7 +33,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 1,
         'PK1' => 'Zhejiang'
@@ -46,7 +46,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 2,
         'PK1' => 'Jiangsu'
@@ -59,7 +59,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 3,
         'PK1' => 'Guangdong'

--- a/src/examples/BatchGetRow4.php
+++ b/src/examples/BatchGetRow4.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 1,
         'PK1' => 'Zhejiang'
@@ -47,7 +47,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 2,
         'PK1' => 'Jiangsu'
@@ -60,7 +60,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 3,
         'PK1' => 'Guangdong'

--- a/src/examples/BatchGetRowWithColumnFilter.php
+++ b/src/examples/BatchGetRowWithColumnFilter.php
@@ -18,8 +18,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -35,7 +35,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 1,
         'PK1' => 'Zhejiang'
@@ -48,7 +48,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 2,
         'PK1' => 'Jiangsu'
@@ -61,7 +61,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array (
         'PK0' => 3,
         'PK1' => 'Guangdong'
@@ -99,7 +99,7 @@ $request = array (
             'column_filter' => array (
                 'column_name' => 'attr1',
                 'value' => 'Shenzhen',
-                'comparator' => ComparatorTypeConst::NOT_EQUAL
+                'comparator' => ComparatorTypeConst::CONST_NOT_EQUAL
             )
         )
     )

--- a/src/examples/BatchWriteRow1.php
+++ b/src/examples/BatchWriteRow1.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -38,7 +38,7 @@ $request = array (
             'table_name' => 'MyTable',
             'put_rows' => array (
                 array ( // 第一行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 1,
                         'PK1' => 'Zhejiang'
@@ -49,7 +49,7 @@ $request = array (
                     )
                 ),
                 array ( // 第二行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 2,
                         'PK1' => 'Jiangsu'
@@ -60,7 +60,7 @@ $request = array (
                     )
                 ),
                 array ( // 第三行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 3,
                         'PK1' => 'Guangdong'

--- a/src/examples/BatchWriteRow2.php
+++ b/src/examples/BatchWriteRow2.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -38,7 +38,7 @@ $request = array (
             'table_name' => 'MyTable',
             'update_rows' => array (
                 array ( // 第一行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 1,
                         'PK1' => 'Zhejiang'
@@ -51,7 +51,7 @@ $request = array (
                     )
                 ),
                 array ( // 第二行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 2,
                         'PK1' => 'Jiangsu'

--- a/src/examples/BatchWriteRow3.php
+++ b/src/examples/BatchWriteRow3.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -38,21 +38,21 @@ $request = array (
             'table_name' => 'MyTable',
             'delete_rows' => array (
                 array ( // 第一行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 1,
                         'PK1' => 'Zhejiang'
                     )
                 ),
                 array ( // 第二行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 2,
                         'PK1' => 'Jiangsu'
                     )
                 ),
                 array ( // 第三行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 3,
                         'PK1' => 'Guangdong'

--- a/src/examples/BatchWriteRow4.php
+++ b/src/examples/BatchWriteRow4.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -38,7 +38,7 @@ $request = array (
             'table_name' => 'MyTable',
             'put_rows' => array (
                 array (
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 1,
                         'PK1' => 'Zhejiang'
@@ -49,7 +49,7 @@ $request = array (
                     )
                 ),
                 array (
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 2,
                         'PK1' => 'Zhejiang'
@@ -62,7 +62,7 @@ $request = array (
             ),
             'update_rows' => array (
                 array ( // 第一行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 3,
                         'PK1' => 'Zhejiang'
@@ -73,7 +73,7 @@ $request = array (
                     )
                 ),
                 array ( // 第二行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 4,
                         'PK1' => 'Jiangsu'
@@ -86,14 +86,14 @@ $request = array (
             ),
             'delete_rows' => array (
                 array ( // 第一行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 5,
                         'PK1' => 'Zhejiang'
                     )
                 ),
                 array ( // 第二行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 6,
                         'PK1' => 'Jiangsu'

--- a/src/examples/BatchWriteRowWithColumnFilter.php
+++ b/src/examples/BatchWriteRowWithColumnFilter.php
@@ -19,8 +19,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -40,7 +40,7 @@ $request = array (
             'table_name' => 'MyTable',
             'put_rows' => array (
                 array (
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 1,
                         'PK1' => 'Zhejiang'
@@ -52,7 +52,7 @@ $request = array (
                 ),
                 array (
                     'condition' => array (
-                        'row_existence' => RowExistenceExpectationConst::IGNORE
+                        'row_existence' => RowExistenceExpectationConst::CONST_IGNORE
                     ),
                     'primary_key' => array (
                         'PK0' => 2,
@@ -67,11 +67,11 @@ $request = array (
             'update_rows' => array (
                 array ( // 第一行
                     'condition' => array (
-                        'row_existence' => RowExistenceExpectationConst::IGNORE,
+                        'row_existence' => RowExistenceExpectationConst::CONST_IGNORE,
                         'column_filter' => array (
                             'column_name' => 'attr2',
                             'value' => 256,
-                            'comparator' => ComparatorTypeConst::NOT_EQUAL
+                            'comparator' => ComparatorTypeConst::CONST_NOT_EQUAL
                         )
                     ),
                     'primary_key' => array (
@@ -85,19 +85,19 @@ $request = array (
                 ),
                 array ( // 第二行
                     'condition' => array (
-                        'row_existence' => RowExistenceExpectationConst::IGNORE,
+                        'row_existence' => RowExistenceExpectationConst::CONST_IGNORE,
                         'column_filter' => array (
-                            'logical_operator' => LogicalOperatorConst::OR,
+                            'logical_operator' => LogicalOperatorConst::CONST_OR,
                             'sub_conditions' => array (
                                 array (
                                     'column_name' => 'attr2',
                                     'value' => 256,
-                                    'comparator' => ComparatorTypeConst::EQUAL
+                                    'comparator' => ComparatorTypeConst::CONST_EQUAL
                                 ),
                                 array (
                                     'column_name' => 'attr1',
                                     'value' => 333,
-                                    'comparator' => ComparatorTypeConst::GREATER_EQUAL
+                                    'comparator' => ComparatorTypeConst::CONST_GREATER_EQUAL
                                 )
                             )
                         )
@@ -114,14 +114,14 @@ $request = array (
             ),
             'delete_rows' => array (
                 array ( // 第一行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 5,
                         'PK1' => 'Zhejiang'
                     )
                 ),
                 array ( // 第二行
-                    'condition' => RowExistenceExpectationConst::IGNORE,
+                    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
                     'primary_key' => array (
                         'PK0' => 6,
                         'PK1' => 'Jiangsu'

--- a/src/examples/CreateTable.php
+++ b/src/examples/CreateTable.php
@@ -16,8 +16,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     

--- a/src/examples/DeleteRow.php
+++ b/src/examples/DeleteRow.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -56,7 +56,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'

--- a/src/examples/DeleteRowWithColumnFilter.php
+++ b/src/examples/DeleteRowWithColumnFilter.php
@@ -19,8 +19,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -37,7 +37,7 @@ sleep (10);
 $request = array (
     'table_name' => 'MyTable',
     'condition' => array (
-        'row_existence' => RowExistenceExpectationConst::IGNORE
+        'row_existence' => RowExistenceExpectationConst::CONST_IGNORE
     ),
     'primary_key' => array ( // 主键
         'PK0' => 123,
@@ -61,19 +61,19 @@ $response = $otsClient->putRow ($request);
 $request = array (
     'table_name' => 'MyTable',
     'condition' => array (
-        'row_existence' => RowExistenceExpectationConst::IGNORE,
+        'row_existence' => RowExistenceExpectationConst::CONST_IGNORE,
         'column_filter' => array (
-            'logical_operator' => LogicalOperatorConst::AND,
+            'logical_operator' => LogicalOperatorConst::CONST_AND,
             'sub_conditions' => array (
                 array (
                     'column_name' => 'attr3',
                     'value' => true,
-                    'comparator' => ComparatorTypeConst::EQUAL
+                    'comparator' => ComparatorTypeConst::CONST_EQUAL
                 ),
                 array (
                     'column_name' => 'attr4',
                     'value' => false,
-                    'comparator' => ComparatorTypeConst::EQUAL
+                    'comparator' => ComparatorTypeConst::CONST_EQUAL
                 )
             )
         )

--- a/src/examples/DeleteTable.php
+++ b/src/examples/DeleteTable.php
@@ -16,8 +16,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),

--- a/src/examples/DescribeTable.php
+++ b/src/examples/DescribeTable.php
@@ -16,8 +16,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),

--- a/src/examples/GetRange1.php
+++ b/src/examples/GetRange1.php
@@ -21,8 +21,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),
@@ -39,7 +39,7 @@ sleep (10);
 for($i = 0; $i < 6000; $i ++) {
   $request = array (
       'table_name' => 'MyTable',
-      'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+      'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
       'primary_key' => array ( // 主键
           'PK0' => $i,
           'PK1' => 'abc'
@@ -59,19 +59,19 @@ for($i = 0; $i < 6000; $i ++) {
 // memory_limit 设置为 256M
 $startPK = array (
     'PK0' => array (
-        'type' => ColumnTypeConst::INF_MIN
+        'type' => ColumnTypeConst::CONST_INF_MIN
     ), // array('type' => 'INF_MIN') 用来表示最小值
     'PK1' => array (
-        'type' => ColumnTypeConst::INF_MIN
+        'type' => ColumnTypeConst::CONST_INF_MIN
     )
 );
 
 $endPK = array (
     'PK0' => array (
-        'type' => ColumnTypeConst::INF_MAX
+        'type' => ColumnTypeConst::CONST_INF_MAX
     ), // array('type' => 'INF_MAX') 用来表示最小值
     'PK1' => array (
-        'type' => ColumnTypeConst::INF_MAX
+        'type' => ColumnTypeConst::CONST_INF_MAX
     )
 );
 
@@ -89,7 +89,7 @@ while (! empty ($startPK)) {
   
   $request = array (
       'table_name' => 'MyTable',
-      'direction' => DirectionConst::FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
+      'direction' => DirectionConst::CONST_FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
       'inclusive_start_primary_key' => $startPK, // 开始主键
       'exclusive_end_primary_key' => $endPK
   ) // 结束主键

--- a/src/examples/GetRange2.php
+++ b/src/examples/GetRange2.php
@@ -21,8 +21,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),
@@ -39,7 +39,7 @@ sleep (10);
 for($i = 0; $i < 6000; $i ++) {
   $request = array (
       'table_name' => 'MyTable',
-      'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+      'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
       'primary_key' => array ( // 主键
           'PK0' => $i,
           'PK1' => 'abc'
@@ -60,19 +60,19 @@ for($i = 0; $i < 6000; $i ++) {
 
 $startPK = array (
     'PK0' => array (
-        'type' => ColumnTypeConst::INF_MIN
+        'type' => ColumnTypeConst::CONST_INF_MIN
     ), // array('type' => 'INF_MIN') 用来表示最小值
     'PK1' => array (
-        'type' => ColumnTypeConst::INF_MIN
+        'type' => ColumnTypeConst::CONST_INF_MIN
     )
 );
 
 $endPK = array (
     'PK0' => array (
-        'type' => ColumnTypeConst::INF_MAX
+        'type' => ColumnTypeConst::CONST_INF_MAX
     ), // array('type' => 'INF_MAX') 用来表示最小值
     'PK1' => array (
-        'type' => ColumnTypeConst::INF_MAX
+        'type' => ColumnTypeConst::CONST_INF_MAX
     )
 );
 
@@ -80,7 +80,7 @@ while (! empty ($startPK)) {
   
   $request = array (
       'table_name' => 'MyTable',
-      'direction' => DirectionConst::FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
+      'direction' => DirectionConst::CONST_FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
       'inclusive_start_primary_key' => $startPK, // 开始主键
       'exclusive_end_primary_key' => $endPK, // 结束主键
       'columns_to_get' => array (

--- a/src/examples/GetRange3.php
+++ b/src/examples/GetRange3.php
@@ -18,8 +18,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),
@@ -36,7 +36,7 @@ sleep (10);
 for($i = 0; $i < 6000; $i ++) {
   $request = array (
       'table_name' => 'MyTable',
-      'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+      'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
       'primary_key' => array ( // 主键
           'PK0' => $i,
           'PK1' => 'abc'
@@ -71,7 +71,7 @@ while (! empty ($startPK) && $limit > 0) {
   
   $request = array (
       'table_name' => 'MyTable',
-      'direction' => DirectionConst::FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
+      'direction' => DirectionConst::CONST_FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
       'inclusive_start_primary_key' => $startPK, // 开始主键
       'exclusive_end_primary_key' => $endPK, // 结束主键
       'limit' => $limit

--- a/src/examples/GetRangeWithColumnFilter.php
+++ b/src/examples/GetRangeWithColumnFilter.php
@@ -20,8 +20,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 ,
@@ -38,7 +38,7 @@ sleep (10);
 for($i = 0; $i < 6000; $i ++) {
   $request = array (
       'table_name' => 'MyTable',
-      'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+      'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
       'primary_key' => array ( // 主键
           'PK0' => $i,
           'PK1' => 'abc'
@@ -73,22 +73,22 @@ while (! empty ($startPK) && $limit > 0) {
   
   $request = array (
       'table_name' => 'MyTable',
-      'direction' => DirectionConst::FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
+      'direction' => DirectionConst::CONST_FORWARD, // 方向可以为 FORWARD 或者 BACKWARD
       'inclusive_start_primary_key' => $startPK, // 开始主键
       'exclusive_end_primary_key' => $endPK, // 结束主键
       'limit' => $limit,
       'column_filter' => array (
-          'logical_operator' => LogicalOperatorConst::AND,
+          'logical_operator' => LogicalOperatorConst::CONST_AND,
           'sub_conditions' => array (
               array (
                   'column_name' => 'attr0',
                   'value' => 456,
-                  'comparator' => ComparatorTypeConst::EQUAL
+                  'comparator' => ComparatorTypeConst::CONST_EQUAL
               ),
               array (
                   'column_name' => 'attr1',
                   'value' => 'Hangzhou',
-                  'comparator' => ComparatorTypeConst::GREATER_EQUAL
+                  'comparator' => ComparatorTypeConst::CONST_GREATER_EQUAL
               )
           )
       )

--- a/src/examples/GetRow.php
+++ b/src/examples/GetRow.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'

--- a/src/examples/GetRow2.php
+++ b/src/examples/GetRow2.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'

--- a/src/examples/GetRowWithMultipleColumnFilter.php
+++ b/src/examples/GetRowWithMultipleColumnFilter.php
@@ -19,8 +19,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 
@@ -37,7 +37,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -69,17 +69,17 @@ $request = array (
         'attr5'
     ), // 只读取 attr0, attr3, attr5 这几列
     'column_filter' => array (
-        "logical_operator" => LogicalOperatorConst::AND, // 对返回的数据进行筛选，只有当attr1为Hanzhou且attr2为3.14的时候才返回数据
+        "logical_operator" => LogicalOperatorConst::CONST_AND, // 对返回的数据进行筛选，只有当attr1为Hanzhou且attr2为3.14的时候才返回数据
         "sub_conditions" => array (
             array (
                 "column_name" => "attr0",
                 "value" => 456,
-                "comparator" => ComparatorTypeConst::EQUAL
+                "comparator" => ComparatorTypeConst::CONST_EQUAL
             ),
             array (
                 'column_name' => 'attr3',
                 'value' => true,
-                'comparator' => ComparatorTypeConst::EQUAL
+                'comparator' => ComparatorTypeConst::CONST_EQUAL
             )
         )
     )

--- a/src/examples/GetRowWithPassIfMissingFalse.php
+++ b/src/examples/GetRowWithPassIfMissingFalse.php
@@ -19,8 +19,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 ,
@@ -36,7 +36,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -68,12 +68,12 @@ $request = array (
         'attr5'
     ), // 只读取 attr0, attr3, attr5 这几列
     'column_filter' => array (
-        "logical_operator" => LogicalOperatorConst::NOT, // 若attr10属性列不存在，则该内层逻辑表达式返回false。则当attr10属性列不存在的时候，得到返回数据。
+        "logical_operator" => LogicalOperatorConst::CONST_NOT, // 若attr10属性列不存在，则该内层逻辑表达式返回false。则当attr10属性列不存在的时候，得到返回数据。
         "sub_conditions" => array (
             array (
                 'column_name' => 'attr10',
                 'value' => 456,
-                'comparator' => ComparatorTypeConst::EQUAL,
+                'comparator' => ComparatorTypeConst::CONST_EQUAL,
                 'pass_if_missing' => false
             )
         )

--- a/src/examples/GetRowWithPassIfMissingTrue.php
+++ b/src/examples/GetRowWithPassIfMissingTrue.php
@@ -19,8 +19,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 ,
@@ -36,7 +36,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -68,18 +68,18 @@ $request = array (
         'attr5'
     ), // 只读取 attr0, attr3, attr5 这几列
     'column_filter' => array (
-        'logical_operator' => LogicalOperatorConst::AND, // 对返回的数据进行筛选，当attr3为true且无论attr10属性列是否存在都返回数据
+        'logical_operator' => LogicalOperatorConst::CONST_AND, // 对返回的数据进行筛选，当attr3为true且无论attr10属性列是否存在都返回数据
         'sub_conditions' => array (
             array (
                 'column_name' => 'attr10',
                 'value' => 456,
-                'comparator' => ComparatorTypeConst::EQUAL,
+                'comparator' => ComparatorTypeConst::CONST_EQUAL,
                 'pass_if_missing' => true
             ),
             array (
                 'column_name' => 'attr3',
                 'value' => true,
-                'comparator' => ComparatorTypeConst::EQUAL
+                'comparator' => ComparatorTypeConst::CONST_EQUAL
             )
         )
     )

--- a/src/examples/GetRowWithSingleColumnFilter.php
+++ b/src/examples/GetRowWithSingleColumnFilter.php
@@ -18,8 +18,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 
@@ -36,7 +36,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -70,7 +70,7 @@ $request = array (
     'column_filter' => array ( // 对返回的数据进行判断，只有当attr0项不为456的时候才返回数据
         'column_name' => 'attr0',
         'value' => 456,
-        'comparator' => ComparatorTypeConst::NOT_EQUAL
+        'comparator' => ComparatorTypeConst::CONST_NOT_EQUAL
     )
 );
 $response = $otsClient->getRow ($request);

--- a/src/examples/ListTable.php
+++ b/src/examples/ListTable.php
@@ -23,8 +23,8 @@ foreach (array (
         'table_meta' => array (
             'table_name' => $tableName, // 表名为 MyTable
             'primary_key_schema' => array (
-                'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-                'PK1' => ColumnTypeConst::STRING
+                'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+                'PK1' => ColumnTypeConst::CONST_STRING
             )
         ), // 第二个主键列名称为PK1, 类型为STRING
         

--- a/src/examples/PutRow.php
+++ b/src/examples/PutRow.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'

--- a/src/examples/PutRowWithColumnFilter.php
+++ b/src/examples/PutRowWithColumnFilter.php
@@ -18,8 +18,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -35,7 +35,7 @@ sleep (10);
 
 $request0 = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::EXPECT_NOT_EXIST,
+    'condition' => RowExistenceExpectationConst::CONST_EXPECT_NOT_EXIST,
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -57,11 +57,11 @@ $response = $otsClient->putRow ($request0);
 $request1 = array (
     'table_name' => 'MyTable',
     'condition' => array (
-        "row_existence" => RowExistenceExpectationConst::EXPECT_EXIST,
+        "row_existence" => RowExistenceExpectationConst::CONST_EXPECT_EXIST,
         "column_filter" => array (
             "column_name" => "attr0",
             "value" => 456,
-            "comparator" => ComparatorTypeConst::EQUAL
+            "comparator" => ComparatorTypeConst::CONST_EQUAL
         )
     ),
     'primary_key' => array ( // 主键

--- a/src/examples/UpdateRow1.php
+++ b/src/examples/UpdateRow1.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 ,
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -58,7 +58,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'

--- a/src/examples/UpdateRow2.php
+++ b/src/examples/UpdateRow2.php
@@ -17,8 +17,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ), // 第二个主键列名称为PK1, 类型为STRING
     
@@ -34,7 +34,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -56,7 +56,7 @@ $response = $otsClient->putRow ($request);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE,
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE,
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'

--- a/src/examples/UpdateRowWithColumnFilter.php
+++ b/src/examples/UpdateRowWithColumnFilter.php
@@ -20,8 +20,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         )
     ) // 第二个主键列名称为PK1, 类型为STRING
 
@@ -38,7 +38,7 @@ sleep (10);
 
 $request = array (
     'table_name' => 'MyTable',
-    'condition' => RowExistenceExpectationConst::IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
+    'condition' => RowExistenceExpectationConst::CONST_IGNORE, // condition可以为IGNORE, EXPECT_EXIST, EXPECT_NOT_EXIST
     'primary_key' => array ( // 主键
         'PK0' => 123,
         'PK1' => 'abc'
@@ -61,11 +61,11 @@ $response = $otsClient->putRow ($request);
 $request = array (
     'table_name' => 'MyTable',
     'condition' => array (
-        'row_existence' => RowExistenceExpectationConst::IGNORE,
+        'row_existence' => RowExistenceExpectationConst::CONST_IGNORE,
         'column_filter' => array ( // 对要操作的目标行的数据进行判断，如果其attr0列为456的时候才删除该目标列
             'column_name' => 'attr0',
             'value' => 456,
-            'comparator' => ComparatorTypeConst::EQUAL
+            'comparator' => ComparatorTypeConst::CONST_EQUAL
         )
     ),
     'primary_key' => array ( // 主键

--- a/src/examples/UpdateTable.php
+++ b/src/examples/UpdateTable.php
@@ -16,8 +16,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),

--- a/src/examples/UpdateTable2.php
+++ b/src/examples/UpdateTable2.php
@@ -16,8 +16,8 @@ $request = array (
     'table_meta' => array (
         'table_name' => 'MyTable', // 表名为 MyTable
         'primary_key_schema' => array (
-            'PK0' => ColumnTypeConst::INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
-            'PK1' => ColumnTypeConst::STRING
+            'PK0' => ColumnTypeConst::CONST_INTEGER, // 第一个主键列（又叫分片键）名称为PK0, 类型为 INTEGER
+            'PK1' => ColumnTypeConst::CONST_STRING
         ) // 第二个主键列名称为PK1, 类型为STRING
 
     ),

--- a/vendor/bin/phpunit
+++ b/vendor/bin/phpunit
@@ -35,7 +35,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
在常量前使用了统一的前缀以避免在大小写不敏感的情况下发生常量名和关键字的冲突。