### PR TITLE
修复设置ErrorLogHandler、DebugLogHandler参数bug

### DIFF
--- a/src/OTS/OTSClientConfig.php
+++ b/src/OTS/OTSClientConfig.php
@@ -78,13 +78,13 @@ class OTSClientConfig
             $this->retryPolicy = $args['RetryPolicy'];
         }
         
-        if (!isset($args['ErrorLogHandler'])) {
+        if (!array_key_exists('ErrorLogHandler', $args)) {
             $this->errorLogHandler = "defaultOTSErrorLogHandler";
         } else {
             $this->errorLogHandler = $args['ErrorLogHandler'];
         }
 
-        if (!isset($args['DebugLogHandler'])) {
+        if (!array_key_exists('DebugLogHandler', $args)) {
             $this->debugLogHandler = 'defaultOTSDebugLogHandler';
         } else {
             $this->debugLogHandler = $args['DebugLogHandler'];


### PR DESCRIPTION
[官方文档](https://help.aliyun.com/document_detail/31757.html?spm=a2c4g.11186623.6.821.c26327deY1eEBq)中写着，创建Client时通过传递ErrorLogHandler、DebugLogHandler参数为null时可以关闭打印日志。但是SDK并不支持这样设置，原因为SDK中使用isset判断是否设置了这两个值，但是isset不能判断null。所以这里需要改成使用array_key_exists进行判断