### PR TITLE
feat: add async request support (asyncSearch, asyncSqlQuery, asyncDoHandle)

### DIFF
--- a/src/OTS/AsyncResponse.php
+++ b/src/OTS/AsyncResponse.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Aliyun\OTS;
+
+use Aliyun\OTS\Handlers\OTSHandlers;
+use Aliyun\OTS\Handlers\RequestContext;
+
+/**
+ * Async response wrapper for OTS API calls.
+ *
+ * Returned by async methods (e.g. asyncSearch, asyncSqlQuery). The underlying HTTP
+ * request is sent immediately and non-blocking. Call wait() to retrieve the result,
+ * or access the response as an array directly — it will auto-resolve on first access.
+ *
+ * Implements ArrayAccess, Countable and IteratorAggregate so it can be used as a
+ * transparent drop-in replacement for the synchronous response array.
+ */
+class AsyncResponse implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    private RequestContext $context;
+    private OTSHandlers $handlers;
+    private bool $resolved = false;
+    private ?array $response = null;
+    private ?\Throwable $exception = null;
+
+    public function __construct(RequestContext $context, OTSHandlers $handlers)
+    {
+        $this->context = $context;
+        $this->handlers = $handlers;
+    }
+
+    /**
+     * Resolve the async response. Returns cached result on subsequent calls.
+     *
+     * @return array
+     * @throws \Throwable
+     */
+    private function resolve(): array
+    {
+        if ($this->resolved) {
+            if ($this->exception !== null) {
+                throw $this->exception;
+            }
+            return $this->response;
+        }
+
+        $this->resolved = true;
+
+        try {
+            $this->response = $this->handlers->resolveAsyncResponse($this->context);
+            return $this->response;
+        } catch (\Throwable $e) {
+            $this->exception = $e;
+            throw $e;
+        }
+    }
+
+    /**
+     * Wait for the async request to complete and return the response.
+     *
+     * @return array
+     * @throws OTSClientException
+     * @throws OTSServerException
+     */
+    public function wait(): array
+    {
+        return $this->resolve();
+    }
+
+    /**
+     * @deprecated Use wait() instead. This method exists for backward compatibility
+     *             with older SDK wrappers and will be removed in a future version.
+     *
+     * @return array
+     * @throws OTSClientException
+     * @throws OTSServerException
+     */
+    public function HWait(): array
+    {
+        return $this->resolve();
+    }
+
+    /**
+     * Whether the async request has been resolved (either successfully or with an error).
+     */
+    public function isResolved(): bool
+    {
+        return $this->resolved;
+    }
+
+    /**
+     * Whether the async request has failed. Triggers resolve if not yet resolved.
+     */
+    public function isFailed(): bool
+    {
+        if (!$this->resolved) {
+            try {
+                $this->resolve();
+            } catch (\Throwable $e) {
+            }
+        }
+        return $this->exception !== null;
+    }
+
+    /**
+     * Whether the async request has succeeded. Triggers resolve if not yet resolved.
+     */
+    public function isSuccessful(): bool
+    {
+        if (!$this->resolved) {
+            try {
+                $this->resolve();
+            } catch (\Throwable $e) {
+            }
+        }
+        return $this->resolved && $this->exception === null;
+    }
+
+    /**
+     * Get the exception if the request failed, or null if it succeeded.
+     */
+    public function getException(): ?\Throwable
+    {
+        return $this->exception;
+    }
+
+    // --- ArrayAccess ---
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->resolve()[$offset]);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->resolve()[$offset];
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        $this->resolve();
+        $this->response[$offset] = $value;
+    }
+
+    public function offsetUnset($offset): void
+    {
+        $this->resolve();
+        unset($this->response[$offset]);
+    }
+
+    // --- Countable ---
+
+    public function count(): int
+    {
+        return count($this->resolve());
+    }
+
+    // --- IteratorAggregate ---
+
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->resolve());
+    }
+
+    /**
+     * Destructor — safely wait for the pending HTTP promise to prevent connection leaks.
+     */
+    public function __destruct()
+    {
+        if (!$this->resolved) {
+            try {
+                $this->context->httpPromise->wait();
+            } catch (\Throwable $e) {
+            }
+        }
+    }
+}

--- a/src/OTS/Handlers/HttpHandler.php
+++ b/src/OTS/Handlers/HttpHandler.php
@@ -51,6 +51,40 @@ class HttpHandler
     }
 
 
+    public function handleBeforeAsync($context)
+    {
+        $uri = "/" . $context->apiName;
+
+        $context->httpPromise = $context->httpClient->requestAsync('POST', $uri, array(
+            'body' => $context->requestBody,
+            'headers' => $context->requestHeaders,
+            'timeout' => $context->clientConfig->socketTimeout,
+            'http_errors' => false,
+        ));
+    }
+
+    public function handleWait($context)
+    {
+        try {
+            $httpResponse = $context->httpPromise->wait();
+            $context->responseHeaders = array();
+            $headers = $httpResponse->getHeaders();
+            foreach ($headers as $key => $value) {
+                $context->responseHeaders[strtolower($key)] = $value[0];
+            }
+
+            $context->responseBody = (string)$httpResponse->getBody();
+            $context->responseHttpStatus = $httpResponse->getStatusCode();
+            $context->responseReasonPhrase = $httpResponse->getReasonPhrase();
+        }
+        catch (TransferException $e)
+        {
+            $otsClientException = new OTSClientException($e->getMessage());
+            $this->logOTSClientException($context, $otsClientException);
+            throw $otsClientException;
+        }
+    }
+
     public function handleAfter($context)
     {
         // empty

--- a/src/OTS/Handlers/OTSHandlers.php
+++ b/src/OTS/Handlers/OTSHandlers.php
@@ -3,6 +3,7 @@
 namespace Aliyun\OTS\Handlers;
 
 use Aliyun\OTS;
+use Aliyun\OTS\AsyncResponse;
 
 
 class OTSHandlers
@@ -77,6 +78,38 @@ class OTSHandlers
             } else {
                 break;
             }
+        }
+
+        return $context->response;
+    }
+
+    public function asyncDoHandle($apiName, array $request): AsyncResponse
+    {
+        $context = new RequestContext($this->clientConfig, $this->httpClient, $apiName, $request);
+
+        $this->retryHandler->handleBefore($context);
+        $this->protoBufferDecoder->handleBefore($context);
+        $this->protoBufferEncoder->handleBefore($context);
+        $this->errorHandler->handleBefore($context);
+        $this->httpHeaderHandler->handleBefore($context);
+        $this->httpHandler->handleBeforeAsync($context);
+
+        return new AsyncResponse($context, $this);
+    }
+
+    public function resolveAsyncResponse(RequestContext $context)
+    {
+        $this->httpHandler->handleWait($context);
+
+        $this->httpHandler->handleAfter($context);
+        $this->httpHeaderHandler->handleAfter($context);
+        $this->errorHandler->handleAfter($context);
+        $this->protoBufferEncoder->handleAfter($context);
+        $this->protoBufferDecoder->handleAfter($context);
+        $this->retryHandler->handleAfter($context);
+
+        if ($context->otsServerException != null) {
+            throw $context->otsServerException;
         }
 
         return $context->response;

--- a/src/OTS/Handlers/RequestContext.php
+++ b/src/OTS/Handlers/RequestContext.php
@@ -25,6 +25,9 @@ class RequestContext
     public $retryDelayInMilliSeconds;
     public $retryTimes;
 
+    /** @var \GuzzleHttp\Promise\PromiseInterface|null */
+    public $httpPromise;
+
     public function __construct(
         \Aliyun\OTS\OTSClientConfig $clientConfig, 
         $httpClient, 

--- a/src/OTS/OTSClient.php
+++ b/src/OTS/OTSClient.php
@@ -544,5 +544,42 @@ class OTSClient
     {
         return $this->handlers->doHandle("SQLQuery", $request);
     }
+
+    /**
+     * 异步执行指定API操作。返回AsyncResponse对象，可调用wait()等待结果，或直接当数组访问自动等待。
+     * @api
+     * @param string $apiName API名称
+     * @param [] $request 请求参数
+     * @return AsyncResponse
+     * @throws OTSClientException 当参数检查出错或服务端返回校验出错时
+     */
+    public function asyncDoHandle($apiName, array $request): AsyncResponse
+    {
+        return $this->handlers->asyncDoHandle($apiName, $request);
+    }
+
+    /**
+     * 异步多元索引查询。返回AsyncResponse对象，可调用wait()等待结果，或直接当数组访问自动等待。
+     * @api
+     * @param [] $request 请求参数
+     * @return AsyncResponse
+     * @throws OTSClientException 当参数检查出错或服务端返回校验出错时
+     */
+    public function asyncSearch(array $request): AsyncResponse
+    {
+        return $this->handlers->asyncDoHandle("Search", $request);
+    }
+
+    /**
+     * 异步SQL查询。返回AsyncResponse对象，可调用wait()等待结果，或直接当数组访问自动等待。
+     * @api
+     * @param [] $request 请求参数
+     * @return AsyncResponse
+     * @throws OTSClientException 当参数检查出错或服务端返回校验出错时
+     */
+    public function asyncSqlQuery(array $request): AsyncResponse
+    {
+        return $this->handlers->asyncDoHandle("SQLQuery", $request);
+    }
 }
 

--- a/tests/OTS/AsyncResponseTest.php
+++ b/tests/OTS/AsyncResponseTest.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace Aliyun\OTS\Tests;
+
+use Aliyun\OTS\AsyncResponse;
+use Aliyun\OTS\Consts\ColumnReturnTypeConst;
+use Aliyun\OTS\Consts\FieldTypeConst;
+use Aliyun\OTS\Consts\PrimaryKeyTypeConst;
+use Aliyun\OTS\Consts\QueryTypeConst;
+use Aliyun\OTS\Consts\RowExistenceExpectationConst;
+use Aliyun\OTS\Consts\SortOrderConst;
+
+require_once __DIR__ . '/TestBase.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+class AsyncResponseTest extends SDKTestBase
+{
+    private static $tableName = 'testAsyncTable';
+    private static $indexName = 'testAsyncIndex';
+
+    public static function setUpBeforeClass(): void
+    {
+        $createTableRequest = array(
+            'table_meta' => array(
+                'table_name' => self::$tableName,
+                'primary_key_schema' => array(
+                    array('PK0', PrimaryKeyTypeConst::CONST_INTEGER),
+                    array('PK1', PrimaryKeyTypeConst::CONST_STRING)
+                )
+            ),
+            'reserved_throughput' => array(
+                'capacity_unit' => array(
+                    'read' => 0,
+                    'write' => 0
+                )
+            ),
+            'table_options' => array(
+                'time_to_live' => -1,
+                'max_versions' => 1,
+                'deviation_cell_version_in_sec' => 86400
+            )
+        );
+        SDKTestBase::createInitialTable($createTableRequest);
+
+        self::createIndex();
+        self::insertData();
+        self::waitForSearchIndexSync();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        SDKTestBase::cleanUpSearchIndex(self::$tableName);
+        SDKTestBase::cleanUp(array(self::$tableName));
+    }
+
+    /**
+     * Test asyncSearch returns AsyncResponse and wait() works.
+     */
+    public function testAsyncSearchWait()
+    {
+        $request = array(
+            'table_name' => self::$tableName,
+            'index_name' => self::$indexName,
+            'search_query' => array(
+                'offset' => 0,
+                'limit' => 10,
+                'get_total_count' => true,
+                'query' => array(
+                    'query_type' => QueryTypeConst::MATCH_ALL_QUERY,
+                ),
+                'sort' => array(
+                    array(
+                        'field_sort' => array(
+                            'field_name' => 'long',
+                            'order' => SortOrderConst::SORT_ORDER_ASC
+                        )
+                    ),
+                ),
+            ),
+            'columns_to_get' => array(
+                'return_type' => ColumnReturnTypeConst::RETURN_ALL,
+            ),
+        );
+
+        $asyncResponse = $this->otsClient->asyncSearch($request);
+
+        $this->assertInstanceOf(AsyncResponse::class, $asyncResponse);
+        $this->assertFalse($asyncResponse->isResolved());
+
+        $result = $asyncResponse->wait();
+
+        $this->assertTrue($asyncResponse->isResolved());
+        $this->assertTrue($asyncResponse->isSuccessful());
+        $this->assertFalse($asyncResponse->isFailed());
+        $this->assertNull($asyncResponse->getException());
+        $this->assertIsArray($result);
+        $this->assertTrue($result['is_all_succeeded']);
+    }
+
+    /**
+     * Test AsyncResponse as transparent array proxy.
+     */
+    public function testAsyncSearchArrayAccess()
+    {
+        $request = array(
+            'table_name' => self::$tableName,
+            'index_name' => self::$indexName,
+            'search_query' => array(
+                'offset' => 0,
+                'limit' => 5,
+                'get_total_count' => true,
+                'query' => array(
+                    'query_type' => QueryTypeConst::MATCH_ALL_QUERY,
+                ),
+                'sort' => array(
+                    array(
+                        'field_sort' => array(
+                            'field_name' => 'long',
+                            'order' => SortOrderConst::SORT_ORDER_ASC
+                        )
+                    ),
+                ),
+            ),
+            'columns_to_get' => array(
+                'return_type' => ColumnReturnTypeConst::RETURN_ALL,
+            ),
+        );
+
+        $asyncResponse = $this->otsClient->asyncSearch($request);
+
+        // ArrayAccess — auto resolves
+        $this->assertTrue(isset($asyncResponse['is_all_succeeded']));
+        $this->assertTrue($asyncResponse['is_all_succeeded']);
+        $this->assertTrue($asyncResponse->isResolved());
+
+        // Countable
+        $this->assertGreaterThan(0, count($asyncResponse));
+
+        // IteratorAggregate
+        $keys = [];
+        foreach ($asyncResponse as $key => $value) {
+            $keys[] = $key;
+        }
+        $this->assertContains('rows', $keys);
+    }
+
+    /**
+     * Test concurrent async requests.
+     */
+    public function testConcurrentAsyncSearch()
+    {
+        $request = array(
+            'table_name' => self::$tableName,
+            'index_name' => self::$indexName,
+            'search_query' => array(
+                'offset' => 0,
+                'limit' => 10,
+                'get_total_count' => true,
+                'query' => array(
+                    'query_type' => QueryTypeConst::MATCH_ALL_QUERY,
+                ),
+                'sort' => array(
+                    array(
+                        'field_sort' => array(
+                            'field_name' => 'long',
+                            'order' => SortOrderConst::SORT_ORDER_ASC
+                        )
+                    ),
+                ),
+            ),
+            'columns_to_get' => array(
+                'return_type' => ColumnReturnTypeConst::RETURN_ALL,
+            ),
+        );
+
+        // Fire 5 concurrent requests
+        $contexts = [];
+        for ($i = 0; $i < 5; $i++) {
+            $contexts[$i] = $this->otsClient->asyncSearch($request);
+        }
+
+        // None should be resolved yet (requests are in-flight)
+        foreach ($contexts as $ctx) {
+            $this->assertInstanceOf(AsyncResponse::class, $ctx);
+        }
+
+        // Wait for all and verify results
+        foreach ($contexts as $i => $ctx) {
+            $result = $ctx->wait();
+            $this->assertIsArray($result);
+            $this->assertTrue($result['is_all_succeeded']);
+            $this->assertEquals(20, $result['total_hits']);
+        }
+    }
+
+    /**
+     * Test asyncDoHandle with ListTable.
+     */
+    public function testAsyncDoHandle()
+    {
+        $asyncResponse = $this->otsClient->asyncDoHandle('ListTable', array());
+
+        $result = $asyncResponse->wait();
+        $this->assertIsArray($result);
+        $this->assertContains(self::$tableName, $result);
+    }
+
+    /**
+     * Test HWait() backward compatibility.
+     */
+    public function testHWaitBackwardCompatibility()
+    {
+        $asyncResponse = $this->otsClient->asyncDoHandle('ListTable', array());
+
+        $result = $asyncResponse->HWait();
+        $this->assertIsArray($result);
+        $this->assertContains(self::$tableName, $result);
+    }
+
+    /**
+     * Test that wait() returns cached result on second call.
+     */
+    public function testWaitCachesResult()
+    {
+        $asyncResponse = $this->otsClient->asyncDoHandle('ListTable', array());
+
+        $result1 = $asyncResponse->wait();
+        $result2 = $asyncResponse->wait();
+        $this->assertSame($result1, $result2);
+    }
+
+    /**
+     * Test asyncSqlQuery.
+     */
+    public function testAsyncSqlQuery()
+    {
+        $asyncResponse = $this->otsClient->asyncSqlQuery(array(
+            'query' => 'SHOW TABLES;',
+        ));
+
+        $this->assertInstanceOf(AsyncResponse::class, $asyncResponse);
+        $result = $asyncResponse->wait();
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('type', $result);
+    }
+
+    /**
+     * Test concurrent asyncSqlQuery requests.
+     */
+    public function testConcurrentAsyncSqlQuery()
+    {
+        $contexts = [];
+        for ($i = 0; $i < 3; $i++) {
+            $contexts[$i] = $this->otsClient->asyncSqlQuery(array(
+                'query' => 'SHOW TABLES;',
+            ));
+        }
+
+        foreach ($contexts as $ctx) {
+            $result = $ctx->wait();
+            $this->assertIsArray($result);
+            $this->assertArrayHasKey('type', $result);
+        }
+    }
+
+    private static function createIndex()
+    {
+        $createIndexRequest = array(
+            'table_name' => self::$tableName,
+            'index_name' => self::$indexName,
+            'schema' => array(
+                'field_schemas' => array(
+                    array(
+                        'field_name' => 'keyword',
+                        'field_type' => FieldTypeConst::KEYWORD,
+                        'index' => true,
+                        'enable_sort_and_agg' => true,
+                        'store' => true,
+                        'is_array' => false
+                    ),
+                    array(
+                        'field_name' => 'long',
+                        'field_type' => FieldTypeConst::LONG,
+                        'index' => true,
+                        'enable_sort_and_agg' => true,
+                        'store' => true,
+                        'is_array' => false
+                    ),
+                ),
+            )
+        );
+        SDKTestBase::createSearchIndex($createIndexRequest);
+    }
+
+    private static function insertData()
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $request = array(
+                'table_name' => self::$tableName,
+                'condition' => RowExistenceExpectationConst::CONST_IGNORE,
+                'primary_key' => array(
+                    array('PK0', $i),
+                    array('PK1', 'async')
+                ),
+                'attribute_columns' => array(
+                    array('keyword', 'test_keyword_' . $i),
+                    array('long', $i),
+                )
+            );
+            SDKTestBase::putInitialData($request);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add native async request support to the SDK, leveraging GuzzleHttp's `requestAsync()` and Promise mechanism. This allows users to fire multiple API calls concurrently and wait for results later, significantly reducing total latency for batch scenarios.

### New public API

| Method | Description |
|--------|-------------|
| `OTSClient::asyncSearch(array $request): AsyncResponse` | Non-blocking Search (multi-index query) |
| `OTSClient::asyncSqlQuery(array $request): AsyncResponse` | Non-blocking SQL query |
| `OTSClient::asyncDoHandle(string $apiName, array $request): AsyncResponse` | Generic async call for any API |

### `AsyncResponse` object

- **`wait(): array`** — block until the response is available
- **`HWait(): array`** — deprecated alias of `wait()`, provided for backward compatibility with existing wrappers and will be removed in a future version
- **Transparent array proxy** — implements `ArrayAccess`, `Countable`, `IteratorAggregate`, so it can be used as a drop-in replacement for the synchronous response array. Accessing any element auto-triggers `wait()`.
- **Status helpers** — `isResolved()`, `isFailed()`, `isSuccessful()`, `getException()`
- **Safe destructor** — if the user never calls `wait()`, the destructor safely drains the HTTP promise to prevent connection leaks

### Usage

```php
// Fire 10 concurrent search requests
$contexts = [];
for ($i = 0; $i < 10; $i++) {
    $contexts[$i] = $ots->asyncSearch($request);
}

// All requests are already in-flight. wait() just collects results.
foreach ($contexts as $ctx) {
    $result = $ctx->wait();
}

// Or use it transparently — auto-waits on first array access:
$result = $ots->asyncSearch($request);
$rows = $result['rows'];           // triggers wait() automatically
foreach ($result as $k => $v) {}   // also auto-waits
```

## Design

The async flow mirrors the existing synchronous handler chain for consistency and maintainability:

```
Sync  doHandle:         handleBefore chain → httpHandler.handleBefore (sync HTTP)      → handleAfter chain
Async asyncDoHandle:    handleBefore chain → httpHandler.handleBeforeAsync (non-blocking) → return AsyncResponse
Async wait():                                httpHandler.handleWait (await promise)     → handleAfter chain
```

### Files changed

| File | Change |
|------|--------|
| `src/OTS/AsyncResponse.php` | **New** — user-facing async response with transparent array proxy |
| `src/OTS/Handlers/HttpHandler.php` | **Modified** — added `handleBeforeAsync()` (sends via `requestAsync`) and `handleWait()` (awaits promise and populates response fields, including error logging) |
| `src/OTS/Handlers/OTSHandlers.php` | **Modified** — added `asyncDoHandle()` and `resolveAsyncResponse()` |
| `src/OTS/Handlers/RequestContext.php` | **Modified** — added `$httpPromise` property |
| `src/OTS/OTSClient.php` | **Modified** — added `asyncDoHandle()`, `asyncSearch()`, `asyncSqlQuery()` |
| `tests/OTS/AsyncResponseTest.php` | **New** — 8 test cases covering wait, array proxy, concurrency, HWait compat, caching, SQL |

## Why this is safe

1. **Zero changes to the synchronous path** — `doHandle()` and all existing handler methods are completely untouched. The sync call flow is identical to before.
2. **No visibility changes** — all existing `private` properties in `OTSHandlers` remain `private`. The new `asyncDoHandle()` and `resolveAsyncResponse()` methods access them from within the same class.
3. **Same handler chain** — the async path uses the exact same handler instances and the same `handleBefore` / `handleAfter` call sequence. The only difference is that the HTTP send (`handleBeforeAsync`) and HTTP receive (`handleWait`) are separated in time.
4. **Header normalization** — `handleWait()` applies `strtolower()` to response header keys, consistent with the sync `handleBefore()`.
5. **Error handling parity** — `handleWait()` catches `TransferException` and wraps it in `OTSClientException` with error logging, identical to the sync path.
6. **No new dependencies** — uses `guzzlehttp/promises` which is already a required dependency via `guzzlehttp/guzzle ^7.10`.
7. **PHP 8.2+ safe** — the new `$httpPromise` property is explicitly declared on `RequestContext`, avoiding dynamic property deprecation warnings.
8. **Connection safety** — `AsyncResponse::__destruct()` ensures the HTTP promise is drained even if the user forgets to call `wait()`.

## Test plan

- [x] `testAsyncSearchWait` — verify `asyncSearch` returns `AsyncResponse`, `wait()` returns correct result
- [x] `testAsyncSearchArrayAccess` — verify `ArrayAccess`, `Countable`, `IteratorAggregate` proxy
- [x] `testConcurrentAsyncSearch` — verify 5 concurrent search requests all return correct results
- [x] `testAsyncDoHandle` — verify generic `asyncDoHandle` with `ListTable`
- [x] `testHWaitBackwardCompatibility` — verify deprecated `HWait()` still works
- [x] `testWaitCachesResult` — verify repeated `wait()` returns cached result
- [x] `testAsyncSqlQuery` — verify `asyncSqlQuery` works
- [x] `testConcurrentAsyncSqlQuery` — verify 3 concurrent SQL queries execute concurrently

All 8 tests pass (47 assertions).