### PR TITLE
fix: add getHandlers() accessor for private handlers property to pres…

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -30,5 +30,8 @@
 			<file>tests/OTS/BatchWriteRowTest.php</file>
 			<file>tests/OTS/GetRangeTest.php</file>
 		</testsuite>
+		<testsuite name="UnitTest">
+			<file>tests/OTS/OTSClientUnitTest.php</file>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/src/OTS/OTSClient.php
+++ b/src/OTS/OTSClient.php
@@ -49,6 +49,15 @@ class OTSClient
     }
 
     /**
+     * 返回 OTSHandlers 对象
+     * @return \Aliyun\OTS\Handlers\OTSHandlers
+     */
+    public function getHandlers()
+    {
+        return $this->handlers;
+    }
+
+    /**
      * 创建表，并设定主键的个数、名称、顺序和类型，以及预留读写吞吐量。
      * API说明：https://help.aliyun.com/document_detail/27312.html
      * @api

--- a/tests/OTS/OTSClientUnitTest.php
+++ b/tests/OTS/OTSClientUnitTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Aliyun\OTS\Tests;
+
+use Aliyun\OTS\OTSClient;
+use Aliyun\OTS\OTSClientConfig;
+use Aliyun\OTS\Handlers\OTSHandlers;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * Unit tests for OTSClient that do not require a real TableStore connection.
+ */
+class OTSClientUnitTest extends TestCase
+{
+    private OTSClient $client;
+
+    protected function setUp(): void
+    {
+        $this->client = new OTSClient([
+            'EndPoint' => 'https://test-instance.cn-hangzhou.ots.aliyuncs.com',
+            'AccessKeyID' => 'test-access-key-id',
+            'AccessKeySecret' => 'test-access-key-secret',
+            'InstanceName' => 'test-instance',
+        ]);
+    }
+
+    public function testGetClientConfigReturnsOTSClientConfig(): void
+    {
+        $config = $this->client->getClientConfig();
+        $this->assertInstanceOf(OTSClientConfig::class, $config);
+    }
+
+    public function testGetHandlersReturnsOTSHandlers(): void
+    {
+        $handlers = $this->client->getHandlers();
+        $this->assertInstanceOf(OTSHandlers::class, $handlers);
+    }
+
+    public function testGetHandlersReturnsSameInstance(): void
+    {
+        $handlers1 = $this->client->getHandlers();
+        $handlers2 = $this->client->getHandlers();
+        $this->assertSame($handlers1, $handlers2, 'getHandlers() should return the same instance on multiple calls');
+    }
+}


### PR DESCRIPTION
> Note to maintainer: Please tag this commit as `v6.0.1` after merging. This patch adds a getHandlers() public accessor to OTSClient, restoring access to the handlers property which was changed from implicit public to private in the recent refactor.


php vendor/bin/phpunit tests/OTS/OTSClientUnitTest.php 
PHPUnit 10.5.63 — PHP 8.5.4
OK (3 tests, 3 assertions)
testGetClientConfigReturnsOTSClientConfig ✅
testGetHandlersReturnsOTSHandlers ✅
testGetHandlersReturnsSameInstance ✅

